### PR TITLE
Dockerize

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -184,6 +184,8 @@ typings/
 
 # dotenv environment variables file
 .env
+server.env
+client.env
 .env.test
 
 # parcel-bundler cache (https://parceljs.org/)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM node
 
-# Working directory
-WORKDIR /usr/src/app
-
 # Build empty project with package- and package-lock.json to enable caching
-COPY package*.json ./
+WORKDIR /tmp
+COPY package*.json /tmp/
+RUN npm config set registry http://registry.npmjs.org/ && npm install
 
-RUN npm i
+WORKDIR /usr/src/app
 
 # Copy over app source
 COPY . .
 
-EXPOSE 8080
+# Re-copy clean node_modules to app dir
+RUN cp -a /tmp/node_modules /usr/src/app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node
+
+# Working directory
+WORKDIR /usr/src/app
+
+# Build empty project with package- and package-lock.json to enable caching
+COPY package*.json ./
+
+RUN npm i
+
+# Copy over app source
+COPY . .
+
+EXPOSE 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,8 @@ services:
   server:
     build: .
     env_file:
-      - server.env
       - .env
-    expose: 
+    expose:
       - ${SERVER_PORT}
     environment:
       SERVER_PORT: ${SERVER_PORT}
@@ -14,28 +13,20 @@ services:
     ports:
       - ${SERVER_PORT}:${SERVER_PORT}
     volumes:
-      - ./src/server:/usr/src/app/src/server
-      - ./src/common:/usr/src/app/src/common
-    links:
+      - ./src:/usr/src/app/src:ro
+    depends_on:
       - mongodb
     command: npm run dev-server
 
   client:
     build: .
-    env_file: 
+    env_file:
       - .env
-    environment:
-      CLIENT_PORT: ${CLIENT_PORT}
-    expose: 
+    expose:
       - ${CLIENT_PORT}
-    ports: 
+    ports:
       - ${CLIENT_PORT}:${CLIENT_PORT}
-    volumes:
-      - ./src/client:/usr/src/app/src/client
-      - ./src/common:/usr/src/app/src/common
-    links:
-      - server
-    command: npm run start
+    command: npm start
 
   mongodb:
     image: mongo:latest
@@ -44,6 +35,6 @@ services:
       MONGO_LOG_DIR: /dev/null
     volumes:
       - ./dist/data/db:/data/db
-    ports:
-      - ${MONGO_PORT}:${MONGO_PORT}
+    expose:
+      - ${MONGO_PORT}
     command: mongod --smallfiles --logpath=/dev/null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+version: '3'
+
+services:
+  server:
+    build: .
+    env_file:
+      - server.env
+      - .env
+    expose: 
+      - ${SERVER_PORT}
+    environment:
+      SERVER_PORT: ${SERVER_PORT}
+      MONGO_BASE_URL: mongodb://mongodb:27017
+    ports:
+      - ${SERVER_PORT}:${SERVER_PORT}
+    volumes:
+      - ./src/server:/usr/src/app/src/server
+      - ./src/common:/usr/src/app/src/common
+    links:
+      - mongodb
+    command: npm run dev-server
+
+  client:
+    build: .
+    env_file: 
+      - .env
+    environment:
+      CLIENT_PORT: ${CLIENT_PORT}
+    expose: 
+      - ${CLIENT_PORT}
+    ports: 
+      - ${CLIENT_PORT}:${CLIENT_PORT}
+    volumes:
+      - ./src/client:/usr/src/app/src/client
+      - ./src/common:/usr/src/app/src/common
+    links:
+      - server
+    command: npm run start
+
+  mongodb:
+    image: mongo:latest
+    environment:
+      MONGO_DATA_DIR: /data/db
+      MONGO_LOG_DIR: /dev/null
+    volumes:
+      - ./dist/data/db:/data/db
+    ports:
+      - ${MONGO_PORT}:${MONGO_PORT}
+    command: mongod --smallfiles --logpath=/dev/null

--- a/package-lock.json
+++ b/package-lock.json
@@ -13272,6 +13272,12 @@
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
+		"picomatch": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
+			"integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
+			"dev": true
+		},
 		"pify": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -16741,6 +16747,126 @@
 					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
+					}
+				}
+			}
+		},
+		"ts-loader": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.0.4.tgz",
+			"integrity": "sha512-p2zJYe7OtwR+49kv4gs7v4dMrfYD1IPpOtqiSPCbe8oR+4zEBtdHwzM7A7M91F+suReqgzZrlClk4LRSSp882g==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.3.0",
+				"enhanced-resolve": "^4.0.0",
+				"loader-utils": "^1.0.2",
+				"micromatch": "^4.0.0",
+				"semver": "^6.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"enhanced-resolve": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
+					"integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"memory-fs": "^0.4.0",
+						"tapable": "^1.0.0"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"memory-fs": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+					"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+					"dev": true,
+					"requires": {
+						"errno": "^0.1.3",
+						"readable-stream": "^2.0.1"
+					}
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"dev": true,
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"semver": {
+					"version": "6.1.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.2.tgz",
+					"integrity": "sha512-z4PqiCpomGtWj8633oeAdXm1Kn1W++3T8epkZYnwiVgIYIJ0QHszhInYSJTYxebByQH7KVCEAn8R9duzZW2PhQ==",
+					"dev": true
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
 					}
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
 		"svg-inline-loader": "^0.8.0",
 		"thread-loader": "^2.1.2",
 		"ts-jest": "^24.0.2",
+		"ts-loader": "^6.0.4",
 		"ts-node": "^8.2.0",
 		"typedoc": "^0.14.2",
 		"typescript": "^3.4.5",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -32,9 +32,7 @@ app.use(bodyParser());
 app.keys = ['secretsauce'];
 
 // Authentication using Passport
-if (process.env.NODE_ENV !== 'production') {
-	require('dotenv').config();
-}
+require('dotenv').config();
 require('./auth');
 
 app.use(passport.initialize());
@@ -44,7 +42,7 @@ app.use(passport.session());
 app.use(router.routes());
 app.use(userRouter.routes());
 
-const DB_URL = process.env.MONGO_URL || 'mongodb://localhost:27017/test';
+const DB_URL = `${process.env.MONGO_BASE_URL || 'mongodb://localhost:27017'}/test`;
 
 // Connect to mongo database
 if (!process.env.MONGO_BASE_URL) throw 'MONGO_BASE_URL not set';

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -47,6 +47,7 @@ app.use(userRouter.routes());
 const DB_URL = process.env.MONGO_URL || 'mongodb://localhost:27017/test';
 
 // Connect to mongo database
+if (!process.env.MONGO_BASE_URL) throw 'MONGO_BASE_URL not set';
 mongoose
 	.connect(DB_URL, {
 		useCreateIndex: true,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,42 +1,28 @@
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
+require('dotenv').config();
 
 const ASSET_PATH = process.env.ASSET_PATH || '/';
 
 module.exports = {
 	context: __dirname, // to automagically find tsconfig.json
-	entry: ['./src/client/index'],
+	entry: './src/client/index',
 	module: {
 		rules: [
 			{
 				// Include ts, tsx, js, and jsx files.
 				exclude: [/server/, /node_modules/],
 				test: /\.(ts|js)x?$/,
-				use: [
-					{
-						loader: 'thread-loader',
-					},
-					{
-						loader: 'babel-loader',
-					},
-				],
+				use: 'babel-loader',
 			},
 			{
 				test: /\.(gif|png|jpe?g)$/i,
-				use: ['file-loader'],
+				use: 'file-loader',
 			},
 			{
 				test: /\.svg$/,
-				oneOf: [
-					{
-						resourceQuery: /inline/,
-						use: ['@svgr/webpack'],
-					},
-					{
-						use: ['@svgr/webpack', 'file-loader'],
-					},
-				],
+				use: ['@svgr/webpack', 'file-loader'],
 			},
 			{
 				include: /node_modules/,

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,5 +1,4 @@
 const merge = require('webpack-merge');
-const ErrorOverlayPlugin = require('error-overlay-webpack-plugin');
 const FriendlyErrorsPlugin = require('friendly-errors-webpack-plugin');
 const webpack = require('webpack');
 const common = require('./webpack.common.js');
@@ -9,15 +8,12 @@ if (!process.env.CLIENT_PORT) throw 'CLIENT_PORT not set';
 if (!process.env.SERVER_PORT) throw 'SERVER_PORT not set';
 
 module.exports = merge.smart(common, {
-	mode: 'development',
-	devtool: 'inline-source-map',
 	devServer: {
-		hot: true, // Enable hot module replacement
-		open: true, // Open browser on 'npm start'
-		quiet: true, // Pretty console output
+		historyApiFallback: true, // Enable hot module replacement
+		host: '0.0.0.0', // Open browser on 'npm start'
+		hot: false, // Pretty console output
+		open: false,
 		port: process.env.CLIENT_PORT,
-		host: '0.0.0.0',
-		historyApiFallback: true,
 		proxy: {
 			'/api': {
 				target: `http://server:${process.env.SERVER_PORT}`,
@@ -26,27 +22,12 @@ module.exports = merge.smart(common, {
 				target: `http://server:${process.env.SERVER_PORT}`,
 			},
 		},
+		quiet: true,
 	},
-	module: {
-		rules: [
-			{
-				// Include ts, tsx, js, and jsx files.
-				test: /\.(ts|js)x?$/,
-				exclude: [/server/, /node_modules/],
-				use: [
-					{
-						loader: 'thread-loader',
-						options: {
-							poolTimeout: Infinity, // set this to Infinity in watch mode - see https://github.com/webpack-contrib/thread-loader
-						},
-					},
-				],
-			},
-		],
-	},
+	devtool: 'inline-source-map',
+	mode: 'development',
 	plugins: [
 		new webpack.HotModuleReplacementPlugin(), // Auto-refresh on changes
-		new ErrorOverlayPlugin(), // Error overlay in browser
 		new FriendlyErrorsPlugin(), // Pretty console output
 	],
 });

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -23,7 +23,7 @@ module.exports = merge.smart(common, {
 				target: `http://server:${process.env.SERVER_PORT}`,
 			},
 			'/graphql': {
-				target: `http://server:${process.env.CLIENT_PORT}`,
+				target: `http://server:${process.env.SERVER_PORT}`,
 			},
 		},
 	},

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -4,6 +4,10 @@ const FriendlyErrorsPlugin = require('friendly-errors-webpack-plugin');
 const webpack = require('webpack');
 const common = require('./webpack.common.js');
 
+// Validate env vars
+if (!process.env.CLIENT_PORT) throw 'CLIENT_PORT not set';
+if (!process.env.SERVER_PORT) throw 'SERVER_PORT not set';
+
 module.exports = merge.smart(common, {
 	mode: 'development',
 	devtool: 'inline-source-map',
@@ -11,11 +15,15 @@ module.exports = merge.smart(common, {
 		hot: true, // Enable hot module replacement
 		open: true, // Open browser on 'npm start'
 		quiet: true, // Pretty console output
-		port: 8081,
+		port: process.env.CLIENT_PORT,
+		host: '0.0.0.0',
 		historyApiFallback: true,
 		proxy: {
 			'/api': {
-				target: 'http://localhost:8080',
+				target: `http://server:${process.env.SERVER_PORT}`,
+			},
+			'/graphql': {
+				target: `http://server:${process.env.CLIENT_PORT}`,
 			},
 		},
 	},

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -2,6 +2,6 @@ const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
 
 module.exports = merge.smart(common, {
-	mode: 'production',
 	devtool: 'source-map',
+	mode: 'production',
 });


### PR DESCRIPTION
## Breaking changes:

1. You must now use `docker-compose up --build` to build and run the container (and `docker-compose up` on subsequent runs). The advantage of this setup is that it only requires one command and will always produce the same result on every platform
2. `.env` now stores three variables, as docker-compose is hardcoded to use this file and we cannot change that: 
```
SERVER_PORT=8080
CLIENT_PORT=8081
MONGO_PORT=27017
```
3. `client.env` now stores all the env vars for the application, and docker-compose injects them into the containers
