### PR TITLE
Moving out default check to separate action

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -34,7 +34,13 @@ action "branch cleanup" {
   }
 }
 
+action "check is default branch" {
+  uses = "actions/bin/filter@master"
+  args = "branch dev"
+}
+
 action "detect dependency changes" {
+  needs = ["check is default branch"]
   uses = "bencooper222/check-for-node-dep-changes@master"
   secrets = ["GITHUB_TOKEN"]
 }


### PR DESCRIPTION
Default detection has been moved out of main action: https://github.com/bencooper222/check-for-node-dep-changes/commit/1e3249760522f56076637d669b6028ce9188a687

So we now have to check ourselves.