### PR TITLE
Dependency change notifications in#vaken-status

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -51,5 +51,5 @@ action "post slack message" {
   secrets = [
     "SLACK_BOT_TOKEN",
   ]
-  args = "{\"channel\": \"CDJEP2U1X\", \"text\": \"One or more dependencies of Vaken in the default branch have been changed; `npm i` is recommended.\"}}"
+  args = "{\"channel\": \"CJ67S2CSK\", \"text\": \"One or more dependencies of Vaken in the default branch have been changed; `npm i` is recommended.\"}}"
 }


### PR DESCRIPTION
Often breaks for mostly GitHub-Actions-is-in-beta reasons. Putting notifications in a less disruptive channel.