### PR TITLE
Add mongoose typegoose peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4725,11 +4725,11 @@
 			"dev": true
 		},
 		"async": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-			"integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+			"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
 			"requires": {
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.10"
 			}
 		},
 		"async-each": {
@@ -10180,8 +10180,7 @@
 		"graceful-fs": {
 			"version": "4.1.15",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-			"dev": true
+			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
 		},
 		"graceful-readlink": {
 			"version": "1.0.1",
@@ -13954,42 +13953,41 @@
 			"integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
 		},
 		"mongodb": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.2.4.tgz",
-			"integrity": "sha512-tjuwdRb89oyCamBG9lWkb7Sf4L/XJ0hsTC22NkbECl3j2X8n+rM+ZlK3dyIPdaJXdc4FOKIRd9dodVJgCtsYMA==",
+			"version": "3.1.13",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.13.tgz",
+			"integrity": "sha512-sz2dhvBZQWf3LRNDhbd30KHVzdjZx9IKC0L+kSZ/gzYquCF5zPOgGqRz6sSCqYZtKP2ekB4nfLxhGtzGHnIKxA==",
 			"requires": {
-				"mongodb-core": "3.2.4",
+				"mongodb-core": "3.1.11",
 				"safe-buffer": "^5.1.2"
 			}
 		},
 		"mongodb-core": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.2.4.tgz",
-			"integrity": "sha512-Ea/fjVntuj0nhLPuDPj54Kce+w4Ee6b1oSM2EvNB4OdwXJ5WIEh79st9/FRZVKwGnc2oB19P1SMSC1noOBXUCQ==",
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.11.tgz",
+			"integrity": "sha512-rD2US2s5qk/ckbiiGFHeu+yKYDXdJ1G87F6CG3YdaZpzdOm5zpoAZd/EKbPmFO6cQZ+XVXBXBJ660sSI0gc6qg==",
 			"requires": {
-				"bson": "^1.1.1",
+				"bson": "^1.1.0",
 				"require_optional": "^1.0.1",
 				"safe-buffer": "^5.1.2",
 				"saslprep": "^1.0.0"
 			}
 		},
 		"mongoose": {
-			"version": "5.5.8",
-			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.5.8.tgz",
-			"integrity": "sha512-BcClXFUAl0L9T57LEztGv+dzHfd8t29cqd3X9NSRHfjHOmj1mduJA3pKSunnb7vah7VvIBCHzEocJtw4Q5WGFA==",
+			"version": "5.4.23",
+			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.4.23.tgz",
+			"integrity": "sha512-23IfTiA9FRJ7yPBFBobpjw5L1OiXzwyAnslB5SI1uN/2nXdd4vqQuP8w0w2ZcrvQ/KP3Mqs02v6n7tc8KzYNMA==",
 			"requires": {
-				"async": "2.6.2",
-				"bson": "~1.1.1",
+				"async": "2.6.1",
+				"bson": "~1.1.0",
 				"kareem": "2.3.0",
-				"mongodb": "3.2.4",
-				"mongodb-core": "3.2.4",
+				"mongodb": "3.1.13",
+				"mongodb-core": "3.1.11",
 				"mongoose-legacy-pluralize": "1.0.2",
-				"mpath": "0.6.0",
+				"mpath": "0.5.1",
 				"mquery": "3.2.0",
 				"ms": "2.1.1",
 				"regexp-clone": "0.0.1",
 				"safe-buffer": "5.1.2",
-				"sift": "7.0.1",
 				"sliced": "1.0.1"
 			},
 			"dependencies": {
@@ -14031,9 +14029,9 @@
 			}
 		},
 		"mpath": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/mpath/-/mpath-0.6.0.tgz",
-			"integrity": "sha512-i75qh79MJ5Xo/sbhxrDrPSEG0H/mr1kcZXJ8dH6URU5jD/knFxCVqVC/gVSW7GIXL/9hHWlT9haLbCXWOll3qw=="
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mpath/-/mpath-0.5.1.tgz",
+			"integrity": "sha512-H8OVQ+QEz82sch4wbODFOz+3YQ61FYz/z3eJ5pIdbMEaUzDqA268Wd+Vt4Paw9TJfvDgVKaayC0gBzMIw2jhsg=="
 		},
 		"mquery": {
 			"version": "3.2.0",
@@ -17609,11 +17607,6 @@
 			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
 			"dev": true
 		},
-		"sift": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/sift/-/sift-7.0.1.tgz",
-			"integrity": "sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g=="
-		},
 		"signal-exit": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -19197,7 +19190,8 @@
 		"typescript": {
 			"version": "3.4.5",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-			"integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw=="
+			"integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+			"dev": true
 		},
 		"typescript-eslint-parser": {
 			"version": "22.0.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"koa-router": "^7.4.0",
 		"koa-session": "^5.11.0",
 		"koa-static": "^5.0.0",
-		"mongoose": "^5.5.8",
+		"mongoose": "^5.4.15",
 		"passport-github2": "^0.1.11",
 		"passport-google-oauth": "^1.0.0",
 		"passport-local": "^1.0.0",


### PR DESCRIPTION
npm kept complaining about this because typegoose wants mongoose as a peer dependency. Of course, it has mongoose as a devDependency so our code never complained about it. My guess is it'll pop up in production.


tl;dr peerDependencies are stupid and never should have been added to npm thanks for coming to my ted talk. 