### PR TITLE
Revert "Upgrade use-immer: 0.1.0 → 0.3.2 (major)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19795,9 +19795,19 @@
 			"dev": true
 		},
 		"use-immer": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.3.2.tgz",
-			"integrity": "sha512-jwNyjTyPTe0vwQ07uIz1x2D/Y6P4WWeaEHyWkuV5+1HtN3+FFxPxOjBKYnIulc0d8khCIYDyiZO56lthkIFHqA=="
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/use-immer/-/use-immer-0.1.0.tgz",
+			"integrity": "sha512-zn/C8S4qB62dKILDq7+BLPYX9I3iAbkqJjTXOi1V1AmM7Elr/0BlOycNKkcKlC/bv6KqPsxE8cN3YM8cQ9/rIg==",
+			"requires": {
+				"immer": "^1.7.3"
+			},
+			"dependencies": {
+				"immer": {
+					"version": "1.12.1",
+					"resolved": "https://registry.npmjs.org/immer/-/immer-1.12.1.tgz",
+					"integrity": "sha512-3fmKM6ovaqDt0CdC9daXpNi5x/YCYS3i4cwLdTVkhJdk5jrDXoPs7lCm3IqM3yhfSnz4tjjxbRG2CziQ7m8ztg=="
+				}
+			}
 		},
 		"util": {
 			"version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
 		"type-graphql": "^0.16.0",
 		"typedoc": "^0.14.2",
 		"typegoose": "^5.6.0",
-		"use-immer": "^0.3.2",
+		"use-immer": "^0.1.0",
 		"yup": "^0.27.0"
 	},
 	"description": "Next-gen hacker registration system",


### PR DESCRIPTION
Reverts VandyHacks/vaken#120

Upgrading does indeed break things.
Old API: [here](https://github.com/immerjs/use-immer/blob/2f6978410c6ec7a769bf1778ee6fbbed36658db1/index.js)
Old types: [here](https://github.com/immerjs/use-immer/blob/2f6978410c6ec7a769bf1778ee6fbbed36658db1/index.d.ts)
New API + types : [here](https://github.com/immerjs/use-immer/blob/master/src/index.ts)