### PR TITLE
Semver node 12.*.* for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 defaults: &defaults
   docker:
-    - image: 'circleci/node:12.2'
+    - image: 'circleci/node:12'
   working_directory: ~/project/vaken
 version: 2.1
 orbs:


### PR DESCRIPTION
So we don't have to constantly bump the version.