### PR TITLE
Fix empty resume field display

### DIFF
--- a/src/client/routes/manage/HackerView.tsx
+++ b/src/client/routes/manage/HackerView.tsx
@@ -146,7 +146,11 @@ export const HackerView: FC<RouteComponentProps<{ id: string }, {}, {}>> = props
 									<DangerousRow
 										key={fieldName}
 										label={`${fieldTitle}:`}
-										value={`<a href="${signedReadUrl}"  target="_blank" rel="noopener noreferrer">Resume Link</a>`}
+										value={
+											signedReadUrl.length > 0
+												? `<a href="${signedReadUrl}"  target="_blank" rel="noopener noreferrer">Resume Link</a>`
+												: 'Not provided'
+										}
 									/>
 								);
 							}


### PR DESCRIPTION
If no resume provided, field will now not have a link.