### PR TITLE
Add user feedback for NFC check-ins

### DIFF
--- a/src/client/routes/nfc/NfcTable.tsx
+++ b/src/client/routes/nfc/NfcTable.tsx
@@ -122,6 +122,8 @@ const NfcTable: FC<NfcTableProps> = ({ hackersData, eventsData }: NfcTableProps)
 	const [unadmitMode, setUnadmitMode] = useState(false);
 	const [eventSelected, setEventSelected] = useState(eventsData[0]);
 
+	const searchBoxRef = React.useRef<HTMLInputElement>(null);
+
 	const [registerNfcUidWithUser] = useRegisterNfcuidWithUserMutation();
 	const [checkInUserToEvent] = useCheckInUserToEventMutation();
 	const [removeUserFromEvent] = useRemoveUserFromEventMutation();
@@ -192,15 +194,15 @@ const NfcTable: FC<NfcTableProps> = ({ hackersData, eventsData }: NfcTableProps)
 						value={searchValue}
 						placeholder="Manual Search"
 						onChange={onSearchBoxEntry(table)}
-						onKeyPress={e => {
+						ref={searchBoxRef}
+						onKeyPress={async e => {
 							if (manualMode && e.key === 'Enter') {
-								const success = handleSubmit(nfcValue, topUserMatch, eventSelected, unadmitMode);
-								if (success) {
-									table.update(draft => {
-										draft.nfcValue = '';
-										draft.searchValue = '';
-									});
-								}
+								await handleSubmit(nfcValue, topUserMatch, eventSelected, unadmitMode);
+								table.update(draft => {
+									draft.nfcValue = '';
+									draft.searchValue = '';
+								});
+								if (searchBoxRef.current) searchBoxRef.current.focus();
 							}
 						}}
 						minWidth="15rem"
@@ -214,15 +216,14 @@ const NfcTable: FC<NfcTableProps> = ({ hackersData, eventsData }: NfcTableProps)
 						value={nfcValue}
 						placeholder="Scan NFC"
 						onChange={onNfcBoxEntry(table)}
-						onKeyPress={e => {
+						onKeyPress={async e => {
 							if (e.key === 'Enter') {
-								const success = handleSubmit(nfcValue, topUserMatch, eventSelected, unadmitMode);
-								if (success) {
-									table.update(draft => {
-										draft.nfcValue = '';
-										draft.searchValue = '';
-									});
-								}
+								await handleSubmit(nfcValue, topUserMatch, eventSelected, unadmitMode);
+								table.update(draft => {
+									draft.nfcValue = '';
+									draft.searchValue = '';
+								});
+								if (searchBoxRef.current) searchBoxRef.current.focus();
 							}
 						}}
 						minWidth="15rem"
@@ -251,13 +252,12 @@ const NfcTable: FC<NfcTableProps> = ({ hackersData, eventsData }: NfcTableProps)
 				</UnadmitToggleWrapper>
 				<HeaderButton
 					onClick={() => {
-						const success = handleSubmit(nfcValue, topUserMatch, eventSelected, unadmitMode);
-						if (success) {
-							table.update(draft => {
-								draft.nfcValue = '';
-								draft.searchValue = '';
-							});
-						}
+						handleSubmit(nfcValue, topUserMatch, eventSelected, unadmitMode);
+						table.update(draft => {
+							draft.nfcValue = '';
+							draft.searchValue = '';
+						});
+						if (searchBoxRef.current) searchBoxRef.current.focus();
 					}}>
 					Submit
 				</HeaderButton>

--- a/src/client/routes/nfc/nfc.graphql.ts
+++ b/src/client/routes/nfc/nfc.graphql.ts
@@ -2,22 +2,42 @@ import gql from 'graphql-tag';
 
 export default gql`
 	mutation registerNFCUIDWithUser($input: NFCRegisterInput!) {
-		registerNFCUIDWithUser(input: $input)
+		registerNFCUIDWithUser(input: $input) {
+			id
+			firstName
+			lastName
+		}
 	}
 
 	mutation checkInUserToEvent($input: EventCheckInInput!) {
-		checkInUserToEvent(input: $input)
+		checkInUserToEvent(input: $input) {
+			id
+			firstName
+			lastName
+		}
 	}
 
 	mutation removeUserFromEvent($input: EventCheckInInput!) {
-		removeUserFromEvent(input: $input)
+		removeUserFromEvent(input: $input) {
+			id
+			firstName
+			lastName
+		}
 	}
 
 	mutation checkInUserToEventByNfc($input: EventCheckInInputByNfc!) {
-		checkInUserToEventByNfc(input: $input)
+		checkInUserToEventByNfc(input: $input) {
+			id
+			firstName
+			lastName
+		}
 	}
 
 	mutation removeUserFromEventByNfc($input: EventCheckInInputByNfc!) {
-		removeUserFromEventByNfc(input: $input)
+		removeUserFromEventByNfc(input: $input) {
+			id
+			firstName
+			lastName
+		}
 	}
 `;

--- a/src/common/schema.graphql.ts
+++ b/src/common/schema.graphql.ts
@@ -389,11 +389,11 @@ export default gql`
 		leaveTeam: Hacker!
 		hackerStatus(input: HackerStatusInput!): Hacker!
 		hackerStatuses(input: HackerStatusesInput!): [Hacker!]!
-		checkInUserToEvent(input: EventCheckInInput!): ID
-		removeUserFromEvent(input: EventCheckInInput!): ID
-		registerNFCUIDWithUser(input: NFCRegisterInput!): ID
-		checkInUserToEventByNfc(input: EventCheckInInputByNfc!): ID
-		removeUserFromEventByNfc(input: EventCheckInInputByNfc!): ID
+		checkInUserToEvent(input: EventCheckInInput!): User!
+		removeUserFromEvent(input: EventCheckInInput!): User!
+		registerNFCUIDWithUser(input: NFCRegisterInput!): User!
+		checkInUserToEventByNfc(input: EventCheckInInputByNfc!): User!
+		removeUserFromEventByNfc(input: EventCheckInInputByNfc!): User!
 		signedUploadUrl(input: ID!): String!
 		confirmMySpot: User!
 		declineMySpot: User!

--- a/src/server/nfc/index.ts
+++ b/src/server/nfc/index.ts
@@ -1,5 +1,6 @@
 import { ObjectID } from 'mongodb';
-import { HackerDbObject } from '../generated/graphql';
+import { AuthenticationError, UserInputError } from 'apollo-server-express';
+import { HackerDbObject, UserDbInterface } from '../generated/graphql';
 import { Models } from '../models';
 
 // TODO: (kenli/timliang) Expand functions for Organizers, Mentors collections
@@ -12,6 +13,27 @@ export async function checkIfNFCUIDExisted(
 		secondaryIds: nfcID,
 	});
 	return hacker;
+}
+
+export async function userIsAttendingEvent(
+	userID: string,
+	eventID: string,
+	models: Models
+): Promise<boolean> {
+	const userObjectID = new ObjectID(userID);
+	const user = await models.Hackers.findOne({ _id: userObjectID, eventsAttended: eventID });
+	return !!user;
+}
+
+export async function shouldWarnRepeatedCheckIn(
+	userID: string,
+	eventID: string,
+	models: Models
+): Promise<boolean> {
+	const event = await models.Events.findOne({ _id: new ObjectID(eventID) });
+	return (
+		event != null && event.warnRepeatedCheckins && userIsAttendingEvent(userID, eventID, models)
+	);
 }
 
 export async function getUser(nfcID: string, models: Models): Promise<HackerDbObject | null> {
@@ -29,109 +51,114 @@ export async function registerNFCUIDWithUser(
 	nfcID: string,
 	userID: string,
 	models: Models
-): Promise<string | null> {
-	if (await isNFCUIDAvailable(nfcID, models)) {
-		const ret = await models.Hackers.findOneAndUpdate(
-			{ _id: new ObjectID(userID) },
-			{
-				$push: {
-					secondaryIds: {
-						$each: [nfcID],
-						$position: 0,
-					},
+): Promise<UserDbInterface> {
+	if (!(await isNFCUIDAvailable(nfcID, models)))
+		throw new AuthenticationError(`NFC ID ${nfcID} not available`);
+
+	const ret = await models.Hackers.findOneAndUpdate(
+		{ _id: new ObjectID(userID) },
+		{
+			$push: {
+				secondaryIds: {
+					$each: [nfcID],
+					$position: 0,
 				},
-			}
-		);
-		if (ret.value !== undefined) return userID;
+			},
+		},
+		{ returnOriginal: false }
+	);
+
+	if (ret.value) {
+		if (ret.value.secondaryIds.length > 1) {
+			throw new Error(`Associated new NFC ID with user overriding the old NFC ID`);
+		}
+		return ret.value;
 	}
-	return null;
+
+	throw new Error(`Unable to associate NFC ID with user: ${userID}. User not found.`);
 }
 
 export async function removeUserFromEvent(
 	userID: string,
 	eventID: string,
 	models: Models
-): Promise<string | null> {
+): Promise<UserDbInterface> {
 	const userObjectID = new ObjectID(userID);
-	const user = await models.Hackers.findOne({ _id: userObjectID });
-	if (user) {
-		const event = await models.Events.findOne({ attendees: userObjectID.toHexString() });
-		if (event) {
-			const ret = await models.Events.updateOne(
-				{ _id: new ObjectID(eventID) },
-				{
-					$pull: {
-						attendees: userObjectID.toHexString(),
-					},
-				}
-			);
-			if (ret.result.ok) return userID;
-		}
+	const user = await models.Hackers.findOne({ _id: userObjectID, eventsAttended: eventID });
+	if (!user) throw new UserInputError(`User has not attended this event`);
+
+	const ret = await Promise.all([
+		models.Events.updateOne(
+			{ _id: new ObjectID(eventID) },
+			{
+				$pull: {
+					attendees: userObjectID.toHexString(),
+				},
+			},
+			{}
+		),
+		models.Hackers.updateOne(
+			{ _id: userObjectID },
+			{
+				$pull: {
+					eventsAttended: eventID,
+				},
+			}
+		),
+	]);
+
+	if (ret[0].result.ok && ret[1].result.ok) {
+		return user;
 	}
-	return null;
+
+	throw new Error(`failed to remove ${user.firstName} ${user.lastName} from event ${eventID}`);
 }
 
 export async function checkInUserToEvent(
 	userID: string,
 	eventID: string,
 	models: Models
-): Promise<string | null> {
+): Promise<UserDbInterface> {
 	const userObjectID = new ObjectID(userID);
 	const eventObjectID = new ObjectID(eventID);
 	const user = await models.Hackers.findOne({ _id: userObjectID });
-	if (user) {
-		const eventCheckInObj = {
-			_id: ObjectID.createFromTime(Date.now()),
-			timestamp: new Date(),
-			user: userID,
-		};
-		const retEvent = await models.Events.findOneAndUpdate(
-			{ _id: eventObjectID },
-			{ $addToSet: { attendees: userObjectID.toHexString() } }
-		);
-		await models.Events.findOneAndUpdate(
-			{ _id: eventObjectID },
-			{ $push: { checkins: eventCheckInObj } }
-		);
-		const retUsr = await models.Hackers.findOneAndUpdate(
-			{ _id: userObjectID },
-			{
-				$addToSet: {
-					eventsAttended: eventObjectID.toHexString(),
-				},
-			}
-		);
-		if (retEvent.ok && retUsr.ok) return userID;
-	}
-	return null;
-}
+	if (!user) if (!user) throw new UserInputError(`user ${userID} not found`);
 
-export async function userIsAttendingEvent(
-	userID: string,
-	eventID: string,
-	models: Models
-): Promise<boolean> {
-	const userObjectID = new ObjectID(userID);
-	const user = await models.Hackers.findOne({ _id: userObjectID });
-	if (user) {
-		const event = await models.Events.findOne({
-			_id: new ObjectID(eventID),
-			attendees: userObjectID.toHexString(),
-		});
-		if (event) return true;
-	}
-	return false;
-}
-
-export async function shouldWarnRepeatedCheckIn(
-	userID: string,
-	eventID: string,
-	models: Models
-): Promise<boolean> {
-	const event = await models.Events.findOne({ _id: new ObjectID(eventID) });
-	return (
-		userIsAttendingEvent(userID, eventID, models) && event != null && event.warnRepeatedCheckins
+	const eventCheckInObj = {
+		_id: ObjectID.createFromTime(Date.now()),
+		timestamp: new Date(),
+		user: userID,
+	};
+	let retEvent = await models.Events.findOneAndUpdate(
+		{ _id: eventObjectID },
+		{
+			$push: { checkins: eventCheckInObj },
+		}
 	);
+
+	// TODO(mattleon): This requires hitting the DB like 5 times rip
+	if (await shouldWarnRepeatedCheckIn(userID, eventID, models)) {
+		throw new Error(`${user.firstName} ${user.lastName} is already checked into event`);
+	}
+	retEvent = await models.Events.findOneAndUpdate(
+		{ _id: eventObjectID },
+		{
+			$addToSet: { attendees: userObjectID.toHexString() },
+		},
+		{ returnOriginal: false }
+	);
+	const retUsr = await models.Hackers.findOneAndUpdate(
+		{ _id: userObjectID },
+		{
+			$addToSet: {
+				eventsAttended: eventObjectID.toHexString(),
+			},
+		},
+		{ returnOriginal: false }
+	);
+	if (retEvent.ok && retUsr.ok && retUsr.value) return retUsr.value;
+
+	throw new Error(`failed checking user <${userID}> into event <${eventID}>`);
 }
 
 export async function getEventsAttended(userID: string, models: Models): Promise<string[]> {

--- a/src/server/nfc/index.ts
+++ b/src/server/nfc/index.ts
@@ -21,8 +21,8 @@ export async function userIsAttendingEvent(
 	models: Models
 ): Promise<boolean> {
 	const userObjectID = new ObjectID(userID);
-	const user = await models.Hackers.findOne({ _id: userObjectID, eventsAttended: eventID });
-	return !!user;
+	const user = await models.Hackers.findOne({ _id: userObjectID });
+	return user !== null && user.eventsAttended && user.eventsAttended.includes(eventID);
 }
 
 export async function shouldWarnRepeatedCheckIn(

--- a/src/server/resolvers/index.ts
+++ b/src/server/resolvers/index.ts
@@ -174,8 +174,7 @@ export const resolvers: CustomResolvers<Context> = {
 		},
 		checkInUserToEvent: async (root, { input }, { models, user }) => {
 			checkIsAuthorizedArray([UserType.Organizer, UserType.Volunteer, UserType.Sponsor], user);
-			const userRet = await checkInUserToEvent(input.user, input.event, models);
-			return userRet;
+			return checkInUserToEvent(input.user, input.event, models);
 		},
 		createSponsor: async (
 			root,
@@ -276,11 +275,8 @@ export const resolvers: CustomResolvers<Context> = {
 		checkInUserToEventByNfc: async (root, { input }, { models, user }) => {
 			checkIsAuthorizedArray([UserType.Organizer, UserType.Volunteer, UserType.Sponsor], user);
 			const inputUser = await getUser(input.nfcId, models);
-			if (inputUser) {
-				const userRet = await checkInUserToEvent(inputUser._id.toString(), input.event, models);
-				return userRet;
-			}
-			return null;
+			if (!inputUser) throw new UserInputError(`user with nfc id <${input.nfcId}> not found`);
+			return checkInUserToEvent(inputUser._id.toString(), input.event, models);
 		},
 		hackerStatus: async (_, { input: { id, status } }, { user, models }) => {
 			checkIsAuthorized(UserType.Organizer, user);
@@ -369,22 +365,17 @@ export const resolvers: CustomResolvers<Context> = {
 		},
 		registerNFCUIDWithUser: async (root, { input }, { models, user }) => {
 			checkIsAuthorized(UserType.Organizer, user);
-			const userRet = await registerNFCUIDWithUser(input.nfcid, input.user, models);
-			return userRet;
+			return registerNFCUIDWithUser(input.nfcid, input.user, models);
 		},
 		removeUserFromEvent: async (root, { input }, { models, user }) => {
 			checkIsAuthorizedArray([UserType.Organizer, UserType.Volunteer, UserType.Sponsor], user);
-			const userRet = await removeUserFromEvent(input.user, input.event, models);
-			return userRet;
+			return removeUserFromEvent(input.user, input.event, models);
 		},
 		removeUserFromEventByNfc: async (root, { input }, { models, user }) => {
 			checkIsAuthorizedArray([UserType.Organizer, UserType.Volunteer, UserType.Sponsor], user);
 			const inputUser = await getUser(input.nfcId, models);
-			if (inputUser) {
-				const userRet = await removeUserFromEvent(inputUser._id.toString(), input.event, models);
-				return userRet;
-			}
-			return null;
+			if (!inputUser) throw new UserInputError(`user with nfc Id ${input.nfcId} not found`);
+			return removeUserFromEvent(inputUser._id.toString(), input.event, models);
 		},
 		signedUploadUrl: async (_, _2, { user }) => {
 			// Enables a user to update their application


### PR DESCRIPTION
Adds toast messages (errors) for
- checkin: user already checked in, duplicate nfc id
- event scanning: user already went to event
- unadmit: user has not attended event

- fixes a bug where event not removed from user eventsAttended array on unadmit
- fixes autofocus on invalid user scan
- autofocus back to search box whenever user scans

** some other goodies