### PR TITLE
Add removeAbsentEvents mutation to hard sync with GCal

### DIFF
--- a/src/client/routes/events/ManageEventTypes.ts
+++ b/src/client/routes/events/ManageEventTypes.ts
@@ -4,6 +4,8 @@ import {
 	AddOrUpdateEventMutationVariables,
 	AssignEventToCompanyMutation,
 	AssignEventToCompanyMutationVariables,
+	RemoveAbsentEventsMutation,
+	RemoveAbsentEventsMutationVariables,
 } from '../../generated/graphql';
 
 export interface EventUpdate {
@@ -25,4 +27,9 @@ export type AddOrUpdateEventMutationFn = MutationFunction<
 export type AssignEventToCompanyMutationFn = MutationFunction<
 	AssignEventToCompanyMutation,
 	AssignEventToCompanyMutationVariables
+>;
+
+export type RemoveAbsentEventsMutationFn = MutationFunction<
+	RemoveAbsentEventsMutation,
+	RemoveAbsentEventsMutationVariables
 >;

--- a/src/client/routes/events/ManageEvents.tsx
+++ b/src/client/routes/events/ManageEvents.tsx
@@ -13,6 +13,7 @@ import { FlexColumn, FlexRow } from '../../components/Containers/FlexContainers'
 import {
 	useAssignEventToCompanyMutation,
 	useAddOrUpdateEventMutation,
+	useRemoveAbsentEventsMutation,
 	useEventsQuery,
 	useCompaniesQuery,
 } from '../../generated/graphql';
@@ -31,6 +32,7 @@ const ManageEvents: FunctionComponent = (): JSX.Element => {
 	const [output, setOutput] = useState('<>');
 	// const [allEvents, setAllEvents] = useState('<all events>');
 	const [addOrUpdateEvent] = useAddOrUpdateEventMutation();
+	const [removeAbsentEvents] = useRemoveAbsentEventsMutation();
 	const [assignEventToCompany] = useAssignEventToCompanyMutation();
 	// const { loading, error, data } = useEventsQuery();
 
@@ -83,7 +85,11 @@ const ManageEvents: FunctionComponent = (): JSX.Element => {
 		const res = await fetch('/api/manage/events/pull');
 		const resData = await res.json();
 		const eventsList = resData as EventUpdate[];
-		const updatedEvents = await updateEventsHandler(eventsList, addOrUpdateEvent);
+		const updatedEvents = await updateEventsHandler(
+			eventsList,
+			addOrUpdateEvent,
+			removeAbsentEvents
+		);
 		setOutput(JSON.stringify(updatedEvents, null, '\t'));
 		// setAllEvents(data.events);
 		// Place holder for events table showing all events, and some UI component listing events just pulled

--- a/src/client/routes/events/events.graphql.ts
+++ b/src/client/routes/events/events.graphql.ts
@@ -28,4 +28,8 @@ export default gql`
 			name
 		}
 	}
+
+	mutation removeAbsentEvents($input: IdListInput!) {
+		removeAbsentEvents(input: $input)
+	}
 `;

--- a/src/client/routes/events/helpers.ts
+++ b/src/client/routes/events/helpers.ts
@@ -2,14 +2,16 @@ import {
 	EventUpdate,
 	AddOrUpdateEventMutationFn,
 	AssignEventToCompanyMutationFn,
+	RemoveAbsentEventsMutationFn,
 } from './ManageEventTypes';
 
 export async function updateEventsHandler(
 	events: null | EventUpdate[],
-	addOrUpdateEventFunction: AddOrUpdateEventMutationFn
+	addOrUpdateEventFunction: AddOrUpdateEventMutationFn,
+	removeAbsentEventsFunction: RemoveAbsentEventsMutationFn
 ): Promise<string[]> {
 	if (events) {
-		return Promise.all(
+		const updatedEvents = await Promise.all(
 			events.map(async event => {
 				const result = await addOrUpdateEventFunction({
 					variables: {
@@ -22,9 +24,22 @@ export async function updateEventsHandler(
 				if (!result.data)
 					throw new Error(`${(result.errors || []).map(error => JSON.stringify(error))}`);
 
-				return result.data.addOrUpdateEvent.name;
+				return result.data.addOrUpdateEvent;
 			})
 		);
+
+		const removeRet = await removeAbsentEventsFunction({
+			variables: {
+				input: {
+					ids: updatedEvents.map(e => e.id),
+				},
+			},
+		});
+
+		if (!removeRet.data)
+			throw new Error(`${(removeRet.errors || []).map(error => JSON.stringify(error))}`);
+
+		return updatedEvents.map(e => e.name);
 	}
 	return [];
 }

--- a/src/common/schema.graphql.ts
+++ b/src/common/schema.graphql.ts
@@ -384,7 +384,12 @@ export default gql`
 		eventId: String!
 	}
 
+	input IdListInput {
+		ids: [ID!]!
+	}
+
 	type Mutation {
+		removeAbsentEvents(input: IdListInput!): Int!
 		assignEventToCompany(input: AssignSponsorEventInput!): Event!
 		addOrUpdateEvent(input: EventUpdateInput!): Event!
 		createCompany(input: CompanyInput!): Company!

--- a/src/server/events/index.ts
+++ b/src/server/events/index.ts
@@ -71,7 +71,7 @@ export async function pullCalendar(calendarID: string | undefined): Promise<Even
 
 /**
  * @param eventInput Object using EventUpdateInput Input type to define what needs to be updated
- * @returns Event name in a promise
+ * @returns Event
  */
 export async function addOrUpdateEvent(
 	eventInput: EventUpdateInput,
@@ -121,6 +121,21 @@ export async function addOrUpdateEvent(
 			`Event ${eventInput.name} <${value}> unsuccessful: ${JSON.stringify(lastErrorObject)}`
 		);
 	return value;
+}
+
+/**
+ * Remove all events from DB that are not in param list eventIDS
+ * @param eventIDs list of object event IDs
+ */
+export async function removeAbsentEvents(eventIDs: ObjectID[], models: Models): Promise<number> {
+	const ret = await models.Events.deleteMany({
+		_id: {
+			$nin: eventIDs,
+		},
+	});
+	if (ret.deletedCount === undefined)
+		throw new Error(`Could not remove multiple events: ${eventIDs}}`);
+	return ret.deletedCount;
 }
 
 export async function getCompanyEvents(

--- a/src/server/resolvers/index.ts
+++ b/src/server/resolvers/index.ts
@@ -24,7 +24,7 @@ import {
 	checkIsAuthorizedArray,
 } from './helpers';
 import { checkInUserToEvent, removeUserFromEvent, registerNFCUIDWithUser, getUser } from '../nfc';
-import { addOrUpdateEvent, assignEventToCompany } from '../events';
+import { addOrUpdateEvent, assignEventToCompany, removeAbsentEvents } from '../events';
 import { getSignedUploadUrl, getSignedReadUrl } from '../storage/gcp';
 import { sendStatusEmail } from '../mail/aws';
 import CONSTANTS from '../../common/constants.json';
@@ -376,6 +376,11 @@ export const resolvers: CustomResolvers<Context> = {
 		registerNFCUIDWithUser: async (root, { input }, { models, user }) => {
 			checkIsAuthorized(UserType.Organizer, user);
 			return registerNFCUIDWithUser(input.nfcid, input.user, models);
+		},
+		removeAbsentEvents: async (root, { input }, { models, user }) => {
+			checkIsAuthorized(UserType.Organizer, user);
+			const objectIds = input.ids.map(id => ObjectID.createFromHexString(id));
+			return removeAbsentEvents(objectIds, models);
 		},
 		removeUserFromEvent: async (root, { input }, { models, user }) => {
 			checkIsAuthorizedArray([UserType.Organizer, UserType.Volunteer, UserType.Sponsor], user);


### PR DESCRIPTION
Solves #493 

Added mutation `removeAbsentEvents` that takes in a list of event object IDs and outputs a number of events removed from the database. All events not in the input list of IDs are removed.

This enables our calendar sync function to be 'hard', meaning that the database will exactly mirror whichever events exist in Google Calendar upon pulling. 