### PR TITLE
Add Check-in Events funcationality for Hackers

### DIFF
--- a/src/client/assets/routes.js
+++ b/src/client/assets/routes.js
@@ -57,6 +57,12 @@ const routes = [
 		path: '/manage/events',
 	},
 	{
+		authLevel: [UserType.Hacker],
+		component: React.lazy(() => import('../routes/events/CheckInEvents')),
+		displayText: 'Check-In Events',
+		path: '/manage/events',
+	},
+	{
 		authLevel: [UserType.Sponsor],
 		component: React.lazy(() => import('../routes/manage/SponsorHackerView')),
 		displayText: 'View Hackers',

--- a/src/client/assets/routes.js
+++ b/src/client/assets/routes.js
@@ -60,7 +60,7 @@ const routes = [
 		authLevel: [UserType.Hacker],
 		component: React.lazy(() => import('../routes/events/CheckInEvents')),
 		displayText: 'Check-In Events',
-		path: '/manage/events',
+		path: '/checkin',
 	},
 	{
 		authLevel: [UserType.Sponsor],

--- a/src/client/routes/events/CheckInEvents.tsx
+++ b/src/client/routes/events/CheckInEvents.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useState, useEffect, RefObject } from 'react';
+import React, { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import { toast } from 'react-toastify';
 import TextButton, { StyledLoginBtn } from '../../components/Buttons/TextButton';
@@ -6,7 +6,6 @@ import FloatingPopup from '../../components/Containers/FloatingPopup';
 import { FlexColumn, FlexStartColumn } from '../../components/Containers/FlexContainers';
 import { Title } from '../../components/Text/Title';
 import STRINGS from '../../assets/strings.json';
-import { ButtonOutline, CenterButtonText } from '../../components/Buttons/Buttons';
 import { SmallCenteredText } from '../../components/Text/SmallCenteredText';
 import { GraphQLErrorMessage } from '../../components/Text/ErrorMessage';
 import {
@@ -59,6 +58,7 @@ export const CheckInEvent: FunctionComponent = (): JSX.Element => {
 		eventType: string;
 		duration: number;
 		startTimestamp: number;
+		eventScore: number;
 	}
 
 	const eventRows: Event[] = eventsData.events.map(
@@ -69,6 +69,7 @@ export const CheckInEvent: FunctionComponent = (): JSX.Element => {
 				eventType: e.eventType,
 				duration: e.duration,
 				startTimestamp: e.startTimestamp,
+				eventScore: e.eventScore ? e.eventScore : 0,
 			};
 		}
 	);
@@ -123,7 +124,7 @@ export const CheckInEvent: FunctionComponent = (): JSX.Element => {
 												return updateEventScore({
 													variables: {
 														input: {
-															eventScore: row.duration,
+															eventScore: row.eventScore,
 															user: data.me.id,
 														},
 													},

--- a/src/client/routes/events/CheckInEvents.tsx
+++ b/src/client/routes/events/CheckInEvents.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent, useState, useEffect, RefObject } from 'react';
 import styled from 'styled-components';
+import { toast } from 'react-toastify';
 import TextButton, { StyledLoginBtn } from '../../components/Buttons/TextButton';
 import FloatingPopup from '../../components/Containers/FloatingPopup';
 import { FlexColumn, FlexStartColumn } from '../../components/Containers/FlexContainers';
@@ -7,7 +8,7 @@ import { Title } from '../../components/Text/Title';
 import STRINGS from '../../assets/strings.json';
 import { ButtonOutline, CenterButtonText } from '../../components/Buttons/Buttons';
 import { SmallCenteredText } from '../../components/Text/SmallCenteredText';
-import { useMyStatusQuery } from '../../generated/graphql';
+import { useMyStatusQuery, CheckInUserToEventMutation } from '../../generated/graphql';
 
 const HackerDashBG = styled(FloatingPopup)`
 	border-radius: 8px;
@@ -31,18 +32,31 @@ const HackerDashBG = styled(FloatingPopup)`
 export const CheckInEvent: FunctionComponent = (): JSX.Element => {
 	const { data, loading } = useMyStatusQuery();
 
+	//
+	const ongoingEvent = {
+		title: 'Welcome',
+	};
+
+	const [eventAttended, setEventAttended] = useState(false);
+
 	useEffect((): void => {
 		if (data && data.me && data.me.__typename === 'Hacker') {
 			console.log(data.me.status);
 		}
 	}, [data]);
 
+	// check if user already registered
+	// useEffect();
+
+	// fetch the ongoing event
+	// useEffect();
+
 	return (
 		<>
 			<FlexStartColumn>
 				<HackerDashBG>
 					<FlexColumn>
-						<Title fontSize="1.75rem">{STRINGS.HACKER_DASHBOARD_HEADER_TEXT}</Title>
+						<Title fontSize="1.75rem">Ongoing Events:</Title>
 						{loading ? null : (
 							<>
 								<ButtonOutline
@@ -63,6 +77,43 @@ export const CheckInEvent: FunctionComponent = (): JSX.Element => {
 									<br />
 									Hello x3
 								</SmallCenteredText>
+								{eventAttended ? (
+									<SmallCenteredText color={`${STRINGS.DARK_TEXT_COLOR}`}>
+										You are already checked in!
+									</SmallCenteredText>
+								) : (
+									<TextButton
+										key={ongoingEvent.title}
+										color="white"
+										fontSize="1.4em"
+										background={STRINGS.ACCENT_COLOR}
+										glowColor="rgba(0, 0, 255, 0.67)"
+										onClick={
+											async () => {
+												toast.dismiss();
+												// checkinUserToEventUpdateScoreMutation
+												// check if the update went successfully
+												if (false) {
+													toast.error('Check-in failed!', {
+														position: 'bottom-right',
+													});
+												} else {
+													// return updateApplication({
+													// 	variables: { input: { fields: input, submit: true } },
+													// }).then(() => {
+													toast.dismiss();
+													return toast.success('You have been checked in successfully!', {
+														position: 'bottom-right',
+													});
+													// });
+												}
+												return Promise.resolve();
+											}
+											// console.log(e);
+										}>
+										Check In
+									</TextButton>
+								)}
 							</>
 						)}
 					</FlexColumn>

--- a/src/client/routes/events/CheckInEvents.tsx
+++ b/src/client/routes/events/CheckInEvents.tsx
@@ -8,7 +8,8 @@ import { Title } from '../../components/Text/Title';
 import STRINGS from '../../assets/strings.json';
 import { ButtonOutline, CenterButtonText } from '../../components/Buttons/Buttons';
 import { SmallCenteredText } from '../../components/Text/SmallCenteredText';
-import { useMyStatusQuery, CheckInUserToEventMutation } from '../../generated/graphql';
+import { GraphQLErrorMessage } from '../../components/Text/ErrorMessage';
+import { useMeQuery, useCheckInUserToEventMutation, useEventsQuery } from '../../generated/graphql';
 
 const HackerDashBG = styled(FloatingPopup)`
 	border-radius: 8px;
@@ -30,26 +31,27 @@ const HackerDashBG = styled(FloatingPopup)`
 `;
 
 export const CheckInEvent: FunctionComponent = (): JSX.Element => {
-	const { data, loading } = useMyStatusQuery();
+	const { data, loading } = useMeQuery();
+	const eventsQuery = useEventsQuery();
+	const eventsLoading = eventsQuery.loading;
+	const eventsError = eventsQuery.error;
+	const eventsData = eventsQuery.data;
 
-	//
-	const ongoingEvent = {
-		title: 'Welcome',
-	};
+	if (eventsError) {
+		console.log(eventsError);
+		return <GraphQLErrorMessage text={STRINGS.GRAPHQL_ORGANIZER_ERROR_MESSAGE} />;
+	}
 
-	const [eventAttended, setEventAttended] = useState(false);
-
-	useEffect((): void => {
-		if (data && data.me && data.me.__typename === 'Hacker') {
-			console.log(data.me.status);
-		}
-	}, [data]);
-
-	// check if user already registered
-	// useEffect();
-
-	// fetch the ongoing event
-	// useEffect();
+	const eventRows = eventsData.events
+		.map(e => {
+			return {
+				id: e.id,
+				name: e.name,
+				eventType: e.eventType,
+				startTimestamp: new Date(e.startTimestamp),
+			};
+		})
+		.sort((a, b) => a.startTimestamp.getTime() - b.startTimestamp.getTime());
 
 	return (
 		<>
@@ -59,7 +61,7 @@ export const CheckInEvent: FunctionComponent = (): JSX.Element => {
 						<Title fontSize="1.75rem">Ongoing Events:</Title>
 						{loading ? null : (
 							<>
-								<ButtonOutline
+								{/* <ButtonOutline
 									paddingLeft="4rem"
 									paddingRight="4rem"
 									width="auto"
@@ -68,7 +70,7 @@ export const CheckInEvent: FunctionComponent = (): JSX.Element => {
 									<CenterButtonText color="#FFFFFF" fontSize="1.8rem">
 										Hello
 									</CenterButtonText>
-								</ButtonOutline>
+								</ButtonOutline> */}
 								<SmallCenteredText
 									color={`${STRINGS.DARK_TEXT_COLOR}`}
 									fontSize="1rem"
@@ -83,34 +85,28 @@ export const CheckInEvent: FunctionComponent = (): JSX.Element => {
 									</SmallCenteredText>
 								) : (
 									<TextButton
-										key={ongoingEvent.title}
+										key={event.id}
 										color="white"
 										fontSize="1.4em"
 										background={STRINGS.ACCENT_COLOR}
 										glowColor="rgba(0, 0, 255, 0.67)"
-										onClick={
-											async () => {
+										onClick={async () => {
+											toast.dismiss();
+											// checkinUserToEventUpdateScoreMutation
+											// check if the update went successfully
+											if (false) {
+												toast.error('Check-in failed!', {
+													position: 'bottom-right',
+												});
+											} else {
 												toast.dismiss();
-												// checkinUserToEventUpdateScoreMutation
-												// check if the update went successfully
-												if (false) {
-													toast.error('Check-in failed!', {
-														position: 'bottom-right',
-													});
-												} else {
-													// return updateApplication({
-													// 	variables: { input: { fields: input, submit: true } },
-													// }).then(() => {
-													toast.dismiss();
-													return toast.success('You have been checked in successfully!', {
-														position: 'bottom-right',
-													});
-													// });
-												}
-												return Promise.resolve();
+												return toast.success('You have been checked in successfully!', {
+													position: 'bottom-right',
+												});
+												// });
 											}
-											// console.log(e);
-										}>
+											return Promise.resolve();
+										}}>
 										Check In
 									</TextButton>
 								)}

--- a/src/client/routes/events/CheckInEvents.tsx
+++ b/src/client/routes/events/CheckInEvents.tsx
@@ -1,0 +1,75 @@
+import React, { FunctionComponent, useState, useEffect, RefObject } from 'react';
+import styled from 'styled-components';
+import TextButton, { StyledLoginBtn } from '../../components/Buttons/TextButton';
+import FloatingPopup from '../../components/Containers/FloatingPopup';
+import { FlexColumn, FlexStartColumn } from '../../components/Containers/FlexContainers';
+import { Title } from '../../components/Text/Title';
+import STRINGS from '../../assets/strings.json';
+import { ButtonOutline, CenterButtonText } from '../../components/Buttons/Buttons';
+import { SmallCenteredText } from '../../components/Text/SmallCenteredText';
+import { useMyStatusQuery } from '../../generated/graphql';
+
+const HackerDashBG = styled(FloatingPopup)`
+	border-radius: 8px;
+	height: min-content;
+	width: 36rem;
+	background: rgba(247, 245, 249, 1);
+	padding: 1.5rem;
+
+	@media screen and (max-width: 456px) {
+		width: 100%;
+	}
+
+	@media screen and (max-width: 400px) {
+		a,
+		${StyledLoginBtn} {
+			width: 100%;
+		}
+	}
+`;
+
+export const CheckInEvent: FunctionComponent = (): JSX.Element => {
+	const { data, loading } = useMyStatusQuery();
+
+	useEffect((): void => {
+		if (data && data.me && data.me.__typename === 'Hacker') {
+			console.log(data.me.status);
+		}
+	}, [data]);
+
+	return (
+		<>
+			<FlexStartColumn>
+				<HackerDashBG>
+					<FlexColumn>
+						<Title fontSize="1.75rem">{STRINGS.HACKER_DASHBOARD_HEADER_TEXT}</Title>
+						{loading ? null : (
+							<>
+								<ButtonOutline
+									paddingLeft="4rem"
+									paddingRight="4rem"
+									width="auto"
+									background="#FFFFFF"
+									glowColor="null">
+									<CenterButtonText color="#FFFFFF" fontSize="1.8rem">
+										Hello
+									</CenterButtonText>
+								</ButtonOutline>
+								<SmallCenteredText
+									color={`${STRINGS.DARK_TEXT_COLOR}`}
+									fontSize="1rem"
+									margin="1.4rem">
+									<span style={{ fontWeight: 'bold' }}>Hello Again</span>
+									<br />
+									Hello x3
+								</SmallCenteredText>
+							</>
+						)}
+					</FlexColumn>
+				</HackerDashBG>
+			</FlexStartColumn>
+		</>
+	);
+};
+
+export default CheckInEvent;

--- a/src/client/routes/events/CheckInEvents.tsx
+++ b/src/client/routes/events/CheckInEvents.tsx
@@ -44,6 +44,10 @@ export const CheckInEvent: FunctionComponent = (): JSX.Element => {
 	const eventsError = eventsQuery.error;
 	const eventsData = eventsQuery.data;
 
+	if (loading || !data || !data.me || eventsLoading || !eventsData) {
+		return <Spinner />;
+	}
+
 	if (eventsError) {
 		console.log(eventsError);
 		return <GraphQLErrorMessage text={STRINGS.GRAPHQL_ORGANIZER_ERROR_MESSAGE} />;
@@ -90,64 +94,58 @@ export const CheckInEvent: FunctionComponent = (): JSX.Element => {
 				<HackerDashBG>
 					<FlexColumn>
 						<Title fontSize="1.75rem">Ongoing Events:</Title>
-						{eventsLoading || !eventsData ? (
-							<Spinner />
-						) : (
+						{eventsCurrent.map(row => (
 							<>
-								{eventsCurrent.map(row => (
-									<>
-										<SmallCenteredText
-											key={row.id}
-											color={`${STRINGS.DARK_TEXT_COLOR}`}
-											fontSize="1rem"
-											margin="1.4rem">
-											<span style={{ fontWeight: 'bold' }}>{row.name}</span>
-										</SmallCenteredText>
-										<TextButton
-											key={row.id}
-											color="white"
-											fontSize="1.4em"
-											background={STRINGS.ACCENT_COLOR}
-											glowColor="rgba(0, 0, 255, 0.67)"
-											onClick={async () => {
-												toast.dismiss();
-												return checkInUserToEvent({
+								<SmallCenteredText
+									key={row.id}
+									color={`${STRINGS.DARK_TEXT_COLOR}`}
+									fontSize="1rem"
+									margin="1.4rem">
+									<span style={{ fontWeight: 'bold' }}>{row.name}</span>
+								</SmallCenteredText>
+								<TextButton
+									key={row.id}
+									color="white"
+									fontSize="1.4em"
+									background={STRINGS.ACCENT_COLOR}
+									glowColor="rgba(0, 0, 255, 0.67)"
+									onClick={async () => {
+										toast.dismiss();
+										return checkInUserToEvent({
+											variables: {
+												input: {
+													event: row.id,
+													user: data.me.id,
+												},
+											},
+										})
+											.then(() => {
+												return updateEventScore({
 													variables: {
 														input: {
-															event: row.id,
-															user,
+															eventScore: row.duration,
+															user: data.me.id,
 														},
 													},
-												})
-													.then(() => {
-														updateEventScore({
-															variables: {
-																input: {
-																	eventScore: row.duration,
-																	user,
-																},
-															},
-														});
-													)
-													.then(() => {
-														toast.dismiss();
-														return toast.success('You have been checked in successfully!', {
-															position: 'bottom-right',
-														});
-													})
-													.catch(() => {
-														toast.dismiss();
-														return toast.error('Check-in failed!', {
-															position: 'bottom-right',
-														});
-													});
-											}}>
-											Check In
-										</TextButton>
-									</>
-								))}
+												});
+											})
+											.then(() => {
+												toast.dismiss();
+												return toast.success('You have been checked in successfully!', {
+													position: 'bottom-right',
+												});
+											})
+											.catch(() => {
+												toast.dismiss();
+												return toast.error('Check-in failed!', {
+													position: 'bottom-right',
+												});
+											});
+									}}>
+									Check In
+								</TextButton>
 							</>
-						)}
+						))}
 					</FlexColumn>
 				</HackerDashBG>
 			</FlexStartColumn>

--- a/src/client/routes/events/CheckInEvents.tsx
+++ b/src/client/routes/events/CheckInEvents.tsx
@@ -41,7 +41,7 @@ export const CheckInEvent: FunctionComponent = (): JSX.Element => {
 	const eventsError = eventsQuery.error;
 	const eventsData = eventsQuery.data;
 
-	if (loading || !data || !data.me || eventsLoading || !eventsData) {
+	if (loading || !data || !data.me || !data.me.id || eventsLoading || !eventsData) {
 		return <Spinner />;
 	}
 
@@ -104,7 +104,7 @@ export const CheckInEvent: FunctionComponent = (): JSX.Element => {
 											variables: {
 												input: {
 													event: row.id,
-													user: data.me.id,
+													user: data.me ? data.me.id : '',
 													eventScore: row.eventScore,
 												},
 											},

--- a/src/client/routes/events/ManageEventTypes.ts
+++ b/src/client/routes/events/ManageEventTypes.ts
@@ -15,6 +15,7 @@ export interface EventUpdate {
 	description: string;
 	location: string;
 	eventType: string;
+	eventScore?: number;
 	gcalID?: string;
 	id?: string;
 }

--- a/src/client/routes/events/events.graphql.ts
+++ b/src/client/routes/events/events.graphql.ts
@@ -26,8 +26,8 @@ export default gql`
 		}
 	}
 
-	mutation updateEventScore($input: EventScoreInput!) {
-		updateEventScore(input: $input) {
+	mutation checkInUserToEventAndUpdateEventScore($input: EventCheckInUpdateInput!) {
+		checkInUserToEventAndUpdateEventScore(input: $input) {
 			id
 			eventScore
 		}

--- a/src/client/routes/events/events.graphql.ts
+++ b/src/client/routes/events/events.graphql.ts
@@ -15,6 +15,16 @@ export default gql`
 		}
 	}
 
+	query eventsForHackers {
+		events {
+			id
+			name
+			eventType
+			startTimestamp
+			duration
+		}
+	}
+
 	mutation addOrUpdateEvent($input: EventUpdateInput!) {
 		addOrUpdateEvent(input: $input) {
 			id

--- a/src/client/routes/events/events.graphql.ts
+++ b/src/client/routes/events/events.graphql.ts
@@ -22,14 +22,14 @@ export default gql`
 			eventType
 			startTimestamp
 			duration
+			eventScore
 		}
 	}
 
 	mutation updateEventScore($input: EventScoreInput!) {
 		updateEventScore(input: $input) {
 			id
-			firstName
-			lastName
+			eventScore
 		}
 	}
 

--- a/src/client/routes/events/events.graphql.ts
+++ b/src/client/routes/events/events.graphql.ts
@@ -25,6 +25,14 @@ export default gql`
 		}
 	}
 
+	mutation updateEventScore($input: EventScoreInput!) {
+		updateEventScore(input: $input) {
+			id
+			firstName
+			lastName
+		}
+	}
+
 	mutation addOrUpdateEvent($input: EventUpdateInput!) {
 		addOrUpdateEvent(input: $input) {
 			id

--- a/src/common/schema.graphql.ts
+++ b/src/common/schema.graphql.ts
@@ -17,6 +17,7 @@ export default gql`
 		userType: UserType! @column
 		phoneNumber: String @column
 		eventsAttended: [ID!]! @column
+		eventScore: Int @column
 	}
 
 	enum DietaryRestriction {
@@ -203,6 +204,7 @@ export default gql`
 		shifts: [Shift!]! @embedded
 		skills: [String!]! @column
 		eventsAttended: [ID!]! @column
+		eventScore: Int @column
 	}
 
 	type Team @entity(embedded: true) {
@@ -231,6 +233,7 @@ export default gql`
 		phoneNumber: String
 		company: Company! @embedded
 		eventsAttended: [ID!]! @column
+		eventScore: Int @column
 	}
 
 	type Organizer implements User @entity {
@@ -250,6 +253,7 @@ export default gql`
 		phoneNumber: String
 		permissions: [String]! @column
 		eventsAttended: [ID!]! @column
+		eventScore: Int @column
 	}
 
 	type Volunteer implements User @entity {

--- a/src/common/schema.graphql.ts
+++ b/src/common/schema.graphql.ts
@@ -143,13 +143,14 @@ export default gql`
 		eventType: String! @column
 		gcalID: String @column
 		owner: Company @embedded
-		eventScore: Int @column
+		eventScore: Int! @column
 	}
 
 	type EventCheckIn @entity(embedded: true) {
 		id: ID! @id @column
 		user: String! @column
 		timestamp: Int! @column(overrideType: "Date")
+		eventScore: Int
 	}
 
 	type Hacker implements User @entity {
@@ -341,8 +342,9 @@ export default gql`
 		event: ID!
 	}
 
-	input EventScoreInput {
+	input EventCheckInUpdateInput {
 		user: ID!
+		event: ID!
 		eventScore: Int!
 	}
 
@@ -396,6 +398,7 @@ export default gql`
 		eventType: String!
 		gcalID: String
 		id: String
+		eventScore: Int
 	}
 
 	input AssignSponsorEventInput {
@@ -421,8 +424,8 @@ export default gql`
 		leaveTeam: Hacker!
 		hackerStatus(input: HackerStatusInput!): Hacker!
 		hackerStatuses(input: HackerStatusesInput!): [Hacker!]!
-		updateEventScore(input: EventScoreInput!): Hacker!
 		checkInUserToEvent(input: EventCheckInInput!): User!
+		checkInUserToEventAndUpdateEventScore(input: EventCheckInUpdateInput!): Hacker!
 		removeUserFromEvent(input: EventCheckInInput!): User!
 		registerNFCUIDWithUser(input: NFCRegisterInput!): User!
 		checkInUserToEventByNfc(input: EventCheckInInputByNfc!): User!

--- a/src/common/schema.graphql.ts
+++ b/src/common/schema.graphql.ts
@@ -17,7 +17,6 @@ export default gql`
 		userType: UserType! @column
 		phoneNumber: String @column
 		eventsAttended: [ID!]! @column
-		eventScore: Int! @column
 	}
 
 	enum DietaryRestriction {
@@ -176,6 +175,7 @@ export default gql`
 		github: String @column
 		team: Team @embedded
 		eventsAttended: [ID!]! @column
+		eventScore: Int @column
 		application: [ApplicationField!]! @embedded
 		emailUnsubscribed: Boolean! @column
 	}
@@ -277,6 +277,7 @@ export default gql`
 		github: String @column
 		team: Team @embedded
 		eventsAttended: [ID!]! @column
+		eventScore: Int @column
 		application: [ApplicationField!]! @embedded
 		emailUnsubscribed: Boolean! @column
 	}
@@ -332,6 +333,11 @@ export default gql`
 	input EventCheckInInput {
 		user: ID!
 		event: ID!
+	}
+
+	input EventScoreInput {
+		user: ID!
+		eventScore: Int!
 	}
 
 	input EventCheckInInputByNfc {
@@ -409,8 +415,8 @@ export default gql`
 		leaveTeam: Hacker!
 		hackerStatus(input: HackerStatusInput!): Hacker!
 		hackerStatuses(input: HackerStatusesInput!): [Hacker!]!
+		updateEventScore(input: EventScoreInput!): Hacker!
 		checkInUserToEvent(input: EventCheckInInput!): User!
-		updateUserEventScore(user: User!, eventScore: Int!): Int!
 		removeUserFromEvent(input: EventCheckInInput!): User!
 		registerNFCUIDWithUser(input: NFCRegisterInput!): User!
 		checkInUserToEventByNfc(input: EventCheckInInputByNfc!): User!

--- a/src/common/schema.graphql.ts
+++ b/src/common/schema.graphql.ts
@@ -143,6 +143,7 @@ export default gql`
 		eventType: String! @column
 		gcalID: String @column
 		owner: Company @embedded
+		eventScore: Int @column
 	}
 
 	type EventCheckIn @entity(embedded: true) {

--- a/src/common/schema.graphql.ts
+++ b/src/common/schema.graphql.ts
@@ -17,6 +17,7 @@ export default gql`
 		userType: UserType! @column
 		phoneNumber: String @column
 		eventsAttended: [ID!]! @column
+		eventScore: Int! @column
 	}
 
 	enum DietaryRestriction {
@@ -409,6 +410,7 @@ export default gql`
 		hackerStatus(input: HackerStatusInput!): Hacker!
 		hackerStatuses(input: HackerStatusesInput!): [Hacker!]!
 		checkInUserToEvent(input: EventCheckInInput!): User!
+		updateUserEventScore(user: User!, eventScore: Int!): Int!
 		removeUserFromEvent(input: EventCheckInInput!): User!
 		registerNFCUIDWithUser(input: NFCRegisterInput!): User!
 		checkInUserToEventByNfc(input: EventCheckInInputByNfc!): User!

--- a/src/common/schema.graphql.ts
+++ b/src/common/schema.graphql.ts
@@ -290,6 +290,7 @@ export default gql`
 		hackers(sortDirection: SortDirection): [Hacker!]!
 		event(id: ID!): Event!
 		events(sortDirection: SortDirection): [Event!]!
+		eventsForHackers(sortDirection: SortDirection): [Event!]!
 		eventCheckIn(id: ID!): EventCheckIn!
 		eventCheckIns(sortDirection: SortDirection): [EventCheckIn!]!
 		sponsor(id: ID!): Sponsor!

--- a/src/server/events/index.test.ts
+++ b/src/server/events/index.test.ts
@@ -37,6 +37,7 @@ const testEvent = ({
 	description: 'testEventdesc',
 	duration: 240,
 	eventType: 'testType',
+	eventScore: 100,
 	location: 'location',
 	name: 'testEventPreexisting',
 	startTimestamp: new Date('2019-09-06T03:41:33.714+00:00'),

--- a/src/server/events/index.ts
+++ b/src/server/events/index.ts
@@ -39,7 +39,16 @@ export const transformCalEventToDBUpdate = (event: Record<string, string>): Even
 		throw new AuthenticationError('Calendar event did not contain start or end timestamp');
 	const parsedStart = new Date(event.start);
 	const parsedEnd = new Date(event.end);
-	const parsedScore = event.description !== '' ? 100 : 0;
+	let parsedScore = 0;
+	if (event.description !== '') {
+		const eDes = event.description
+			.split('\n')
+			.map(s => s.trim())
+			.filter(s => s.startsWith('Points:'));
+		if (eDes.length > 0) {
+			parsedScore = parseInt(eDes[0].split(' ')[1], 10);
+		}
+	}
 	const parsedType = /\[(.*?)\]/.exec(event.description); // Looks for a **single** [Event Type] tag in name
 	return {
 		name: event.summary,
@@ -92,6 +101,7 @@ export async function addOrUpdateEvent(
 		duration: eventInput.duration,
 		description: eventInput.description,
 		location: eventInput.location,
+		eventScore: eventInput.eventScore,
 		eventType: eventInput.eventType,
 		gcalID: eventInput.gcalID,
 	} as EventDbObject;
@@ -105,6 +115,7 @@ export async function addOrUpdateEvent(
 				description: eventDiffObj.description,
 				location: eventDiffObj.location,
 				eventType: eventDiffObj.eventType,
+				eventScore: eventDiffObj.eventScore,
 			},
 			$setOnInsert: {
 				attendees: [],

--- a/src/server/events/index.ts
+++ b/src/server/events/index.ts
@@ -39,6 +39,7 @@ export const transformCalEventToDBUpdate = (event: Record<string, string>): Even
 		throw new AuthenticationError('Calendar event did not contain start or end timestamp');
 	const parsedStart = new Date(event.start);
 	const parsedEnd = new Date(event.end);
+	const parsedScore = event.description !== '' ? 100 : 0;
 	const parsedType = /\[(.*?)\]/.exec(event.description); // Looks for a **single** [Event Type] tag in name
 	return {
 		name: event.summary,
@@ -47,6 +48,7 @@ export const transformCalEventToDBUpdate = (event: Record<string, string>): Even
 		description: event.description.replace(/\s*\[(.*?)\]\s*/, ''), // Removes the [Event Type] tag in name
 		location: event.location,
 		eventType: parsedType != null ? parsedType[1] : '',
+		eventScore: parsedScore,
 		gcalID: event.uid,
 	} as EventUpdate;
 };

--- a/src/server/nfc/index.test.ts
+++ b/src/server/nfc/index.test.ts
@@ -25,6 +25,7 @@ const event: EventDbObject = {
 	eventType: 'event type',
 	location: 'location',
 	name: 'event',
+	eventScore: 100,
 	startTimestamp: new Date(),
 	warnRepeatedCheckins: true,
 };

--- a/src/server/resolvers/index.ts
+++ b/src/server/resolvers/index.ts
@@ -551,13 +551,16 @@ export const resolvers: CustomResolvers<Context> = {
 			return ctx.models.EventCheckIns.find().toArray();
 		},
 		events: async (root, args, ctx) => {
-			const user = checkIsAuthorizedArray([UserType.Organizer, UserType.Sponsor], ctx.user);
+			const user = checkIsAuthorizedArray(
+				[UserType.Organizer, UserType.Sponsor, UserType.Hacker],
+				ctx.user
+			);
 			if (user.userType === UserType.Sponsor) {
 				const { _id } = (user as SponsorDbObject).company;
 				const events = await ctx.models.Events.find({ 'owner._id': new ObjectID(_id) }).toArray();
 				return events;
 			}
-			if (user.userType === UserType.Organizer) {
+			if (user.userType === UserType.Organizer || user.userType === UserType.Hacker) {
 				return ctx.models.Events.find().toArray();
 			}
 			return ctx.models.Events.find({ owner: null }).toArray();

--- a/src/server/resolvers/index.ts
+++ b/src/server/resolvers/index.ts
@@ -535,7 +535,6 @@ export const resolvers: CustomResolvers<Context> = {
 			);
 			if (!ok || !value)
 				throw new UserInputError(`user ${userObject._id} (${value}) error: ${JSON.stringify(err)}`);
-			// no email sent if declined
 			return value;
 		},
 	},

--- a/src/server/resolvers/index.ts
+++ b/src/server/resolvers/index.ts
@@ -1,6 +1,5 @@
 import { UserInputError, AuthenticationError } from 'apollo-server-express';
 import { ObjectID } from 'mongodb';
-import { async } from 'node-ical';
 import {
 	UserType,
 	ShirtSize,

--- a/src/server/resolvers/index.ts
+++ b/src/server/resolvers/index.ts
@@ -562,6 +562,10 @@ export const resolvers: CustomResolvers<Context> = {
 			}
 			return ctx.models.Events.find({ owner: null }).toArray();
 		},
+		eventsForHackers: async (root, args, ctx) => {
+			const user = checkIsAuthorized(UserType.Hacker, ctx.user);
+			return ctx.models.Events.find().toArray();
+		},
 		company: async (root, { id }, ctx) => queryById(id, ctx.models.Companies),
 		companies: async (root, args, ctx) => {
 			checkIsAuthorizedArray([UserType.Organizer, UserType.Volunteer], ctx.user);


### PR DESCRIPTION
Flow: Organizer has to pull events from calendar inside `manage events` once so that the events are created in the db. Then, the `check-in` shows at any time the ongoing events which people can check-in to.
![ongoingevent](https://user-images.githubusercontent.com/10655165/94744833-40357400-033f-11eb-950e-39171a556789.png)


Closes #677 