### PR TITLE
check if .env exists before overwriting in installation

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,8 +4,11 @@
 ENVFILE=".env"
 GLOBAL_DEPS=("webpack" "webpack-cli" "typescript" "ts-node")
 
-cp "$ENVFILE.template" "$ENVFILE"
-echo "Please update $ENVFILE with valid environment variables."
+# check if envfile exists
+if [ ! -f $ENVFILE ]; then
+    cp "$ENVFILE.template" "$ENVFILE"
+    echo "Please update $ENVFILE with valid environment variables."
+fi
 
 npm install # local dependencies
 npm install -g "${GLOBAL_DEPS[@]}"


### PR DESCRIPTION
currently, the installation script would overwrite an existing .env which happened with me a couple of times while updating stuff or setting up an installation. 

this checks for its existence before overwriting it.