### PR TITLE
Use HtmlWebpackPlugin to handle favicon

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -8,7 +8,6 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<link href="https://fonts.googleapis.com/css?family=Roboto+Condensed:300,400,500|Roboto:300,400,500,700"
 		rel="stylesheet" />
-	<link rel="icon" href="./assets/img/favicon.ico" type="image/x-icon" />
 </head>
 
 <body>

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -44,6 +44,7 @@ module.exports = {
 		}), // Check types asynchronously
 		new HtmlWebpackPlugin({
 			template: './src/client/index.html',
+			favicon: './src/client/assets/img/favicon.ico',
 		}), // For index.html entry point
 	],
 	resolve: {


### PR DESCRIPTION
Fixes #632 

The issue was caused by lacking a real favicon for the site (which broke at some point when webpack stopped bundling the favicon). The favicon reported in the issue was likely cached for the domain.