### PR TITLE
Elimate typecheck from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,22 +56,6 @@ jobs:
         uses: paambaati/codeclimate-action@v2.7.5
         env:
           CC_TEST_REPORTER_ID: ${{secrets.CC_TEST_REPORTER_ID}}
-  typecheck:
-    name: Check types
-    runs-on: ubuntu-latest
-    steps:
-      - name: Read .nvmrc
-        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-        id: nvm
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "${{ steps.nvm.outputs.NVMRC }}"
-      - run: npm ci
-        env: 
-          MONGOMS_DISABLE_POSTINSTALL: 1
-      - run: npm run generate
-      - run: npm run check:types
   happo:
     name: Happo Screenshot Diffs
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
 		"check:test": "jest",
 		"check:test:snapshot": "jest --updateSnapshot",
 		"check:test:ci": "jest --ci --runInBand",
-		"check:types": "tsc -p tsconfig.json --noEmit",
 		"check:lint": "npm run check:lint:ci -- --cache",
 		"check:lint:fix": "npm run check:lint -- --fix",
 		"check:lint:ci": "eslint --ext .js,.jsx,.ts,.tsx src/ plugins/ scripts/",


### PR DESCRIPTION
# Summary

The typecheck CI job was doing literally nothing that the build step didn't do. `npm run build:server` also just directly called `tsc`. 

