### PR TITLE
Add missing resolvers

### DIFF
--- a/codegen.json
+++ b/codegen.json
@@ -1,25 +1,14 @@
 {
-	"schema": [
-		"./src/common/schema.graphql.ts",
-		"./plugins/**/schema.graphql.ts"
-	],
-	"documents": [
-		"./src/client/**/*.graphql.ts",
-		"./plugins/**/*.graphql.ts"
-	],
+	"schema": ["./src/common/schema.graphql.ts", "./plugins/**/schema.graphql.ts"],
+	"documents": ["./src/client/**/*.graphql.ts", "./plugins/**/*.graphql.ts"],
 	"overwrite": true,
 	"watch": false,
 	"generates": {
 		"src/server/generated/graphql.ts": {
-			"plugins": [
-				"typescript",
-				"typescript-resolvers",
-				"typescript-mongodb"
-			],
+			"plugins": ["typescript", "typescript-resolvers", "typescript-mongodb"],
 			"config": {
 				"mappers": {
 					"ApplicationField": "ApplicationFieldDbObject",
-					"ApplicationQuestion": "ApplicationQuestionDbObject",
 					"_Plugin__Event": "_Plugin__EventDbObject",
 					"_Plugin__EventCheckIn": "_Plugin__EventCheckInDbObject",
 					"Event": "EventDbObject",

--- a/src/common/schema.graphql.ts
+++ b/src/common/schema.graphql.ts
@@ -150,7 +150,6 @@ export default gql`
 		id: ID! @id @column
 		user: String! @column
 		timestamp: Int! @column(overrideType: "Date")
-		eventScore: Int
 	}
 
 	type Hacker implements User @entity {

--- a/src/common/schema.graphql.ts
+++ b/src/common/schema.graphql.ts
@@ -96,12 +96,6 @@ export default gql`
 		DESC
 	}
 
-	type ApplicationQuestion @entity {
-		prompt: String! @column
-		instruction: String @column
-		note: String @column
-	}
-
 	type ApplicationField @entity(embedded: true) {
 		id: ID! @column
 		createdAt: Float! @column(overrideType: "Date")

--- a/src/server/models.ts
+++ b/src/server/models.ts
@@ -2,7 +2,6 @@ import { Collection, MongoClient } from 'mongodb';
 import {
 	ApplicationFieldDbObject,
 	EventDbObject,
-	ApplicationQuestionDbObject,
 	CompanyDbObject,
 	HackerDbObject,
 	SponsorDbObject,
@@ -24,7 +23,6 @@ export interface Models {
 	ApplicationFields: Collection<ApplicationFieldDbObject>;
 	EventCheckIns: Collection<EventCheckInDbObject>;
 	Events: Collection<EventDbObject>;
-	ApplicationQuestions: Collection<ApplicationQuestionDbObject>;
 	Companies: Collection<CompanyDbObject>;
 	Hackers: Collection<HackerDbObject>;
 	Logins: Collection<LoginDbObject>;
@@ -108,7 +106,6 @@ export default class DB {
 					ApplicationFields: db.collection<ApplicationFieldDbObject>('applicationFields'),
 					EventCheckIns: db.collection<EventCheckInDbObject>('EventCheckIns'),
 					Events: db.collection<EventDbObject>('Events'),
-					ApplicationQuestions: db.collection<ApplicationQuestionDbObject>('applicationQuestions'),
 					Companies: db.collection<CompanyDbObject>('companies'),
 					Hackers: db.collection<HackerDbObject>('Hackers'),
 					Logins: db.collection<LoginDbObject>('logins'),

--- a/src/server/resolvers/EventResolver.ts
+++ b/src/server/resolvers/EventResolver.ts
@@ -7,7 +7,6 @@ export const Event: EventResolvers<Context> = {
 	description: async event => (await event).description || null,
 	duration: async event => (await event).duration,
 	eventType: async event => (await event).eventType,
-	eventScore: async event => (await event).eventScore || 0,
 	id: async event => (await event)._id.toHexString(),
 	location: async event => (await event).location,
 	name: async event => (await event).name,

--- a/src/server/resolvers/EventResolver.ts
+++ b/src/server/resolvers/EventResolver.ts
@@ -14,4 +14,5 @@ export const Event: EventResolvers<Context> = {
 	warnRepeatedCheckins: async event => (await event).warnRepeatedCheckins,
 	gcalID: async event => (await event).gcalID || null,
 	owner: async event => (await event).owner || null,
+	eventScore: async event => (await event).eventScore || 0,
 };

--- a/src/server/resolvers/EventResolver.ts
+++ b/src/server/resolvers/EventResolver.ts
@@ -7,6 +7,7 @@ export const Event: EventResolvers<Context> = {
 	description: async event => (await event).description || null,
 	duration: async event => (await event).duration,
 	eventType: async event => (await event).eventType,
+	eventScore: async event => (await event).eventScore || 0,
 	id: async event => (await event)._id.toHexString(),
 	location: async event => (await event).location,
 	name: async event => (await event).name,

--- a/src/server/resolvers/UserResolver.ts
+++ b/src/server/resolvers/UserResolver.ts
@@ -20,4 +20,5 @@ export const User: Omit<UserResolvers, '__resolveType' | 'userType'> = {
 		const { shirtSize } = await user;
 		return shirtSize ? toEnum(ShirtSize)(shirtSize) : null;
 	},
+	eventScore: async user => (await user).eventScore || 0,
 };


### PR DESCRIPTION
# Summary

We've had warnings of these for a while. This actually adds them.

I also deleted ApplicationQuestion entirely because it had 3 missing resolvers and no usage. It looks like it's deprecated in favor of `application.js`