### PR TITLE
Eliminate babel plugins that we don't need

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,6 @@
 	"presets": ["@babel/env", "@babel/preset-typescript", "@babel/preset-react"],
 	"plugins": [
 		"@babel/proposal-class-properties",
-		"@babel/proposal-object-rest-spread",
 		"@babel/proposal-export-namespace-from",
 		"@babel/proposal-throw-expressions",
 		"@babel/syntax-dynamic-import",

--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,6 @@
 	"presets": ["@babel/env", "@babel/preset-typescript", "@babel/preset-react"],
 	"plugins": [
 		"@babel/proposal-class-properties",
-		"@babel/proposal-export-namespace-from",
 		"@babel/proposal-throw-expressions",
 		"@babel/syntax-dynamic-import",
 		"babel-plugin-styled-components"

--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,6 @@
 		"@babel/proposal-export-namespace-from",
 		"@babel/proposal-throw-expressions",
 		"@babel/syntax-dynamic-import",
-		"babel-plugin-styled-components",
-		"@babel/plugin-proposal-optional-chaining"
+		"babel-plugin-styled-components"
 	]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,6 @@
 		"@babel/proposal-throw-expressions",
 		"@babel/syntax-dynamic-import",
 		"babel-plugin-styled-components",
-		"@babel/plugin-proposal-nullish-coalescing-operator",
 		"@babel/plugin-proposal-optional-chaining"
 	]
 }

--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
 	"devDependencies": {
 		"@babel/core": "^7.12.10",
 		"@babel/plugin-proposal-class-properties": "^7.12.1",
-		"@babel/plugin-proposal-export-namespace-from": "^7.12.1",
 		"@babel/plugin-proposal-throw-expressions": "^7.12.1",
 		"@babel/plugin-syntax-dynamic-import": "^7.8.3",
 		"@babel/preset-env": "^7.12.11",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
 		"@babel/plugin-proposal-class-properties": "^7.12.1",
 		"@babel/plugin-proposal-export-namespace-from": "^7.12.1",
 		"@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
-		"@babel/plugin-proposal-object-rest-spread": "^7.12.1",
 		"@babel/plugin-proposal-optional-chaining": "^7.12.7",
 		"@babel/plugin-proposal-throw-expressions": "^7.12.1",
 		"@babel/plugin-syntax-dynamic-import": "^7.8.3",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
 		"@babel/core": "^7.12.10",
 		"@babel/plugin-proposal-class-properties": "^7.12.1",
 		"@babel/plugin-proposal-export-namespace-from": "^7.12.1",
-		"@babel/plugin-proposal-optional-chaining": "^7.12.7",
 		"@babel/plugin-proposal-throw-expressions": "^7.12.1",
 		"@babel/plugin-syntax-dynamic-import": "^7.8.3",
 		"@babel/preset-env": "^7.12.11",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
 		"@babel/core": "^7.12.10",
 		"@babel/plugin-proposal-class-properties": "^7.12.1",
 		"@babel/plugin-proposal-export-namespace-from": "^7.12.1",
-		"@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
 		"@babel/plugin-proposal-optional-chaining": "^7.12.7",
 		"@babel/plugin-proposal-throw-expressions": "^7.12.1",
 		"@babel/plugin-syntax-dynamic-import": "^7.8.3",


### PR DESCRIPTION
# Summary

All of these proposal plugins are in stage 4 (complete) of the ECMAscript spec. No longer need Babel.

Also saves 3kb on our build. 