### PR TITLE
Fix populateDb

### DIFF
--- a/scripts/populateDb.ts
+++ b/scripts/populateDb.ts
@@ -56,7 +56,7 @@ const addHackers = async (): Promise<void> => {
 		newHackers.push(generateHacker());
 	}
 
-	console.log(`Adding the hackes to the DB...`);
+	console.log(`Adding the hackers to the DB...`);
 	const { insertedCount } = await models.Hackers.insertMany(newHackers);
 	console.log(`Inserted ${insertedCount} new hackers`);
 	process.exit(0);

--- a/scripts/populateDb.ts
+++ b/scripts/populateDb.ts
@@ -42,7 +42,7 @@ const generateHacker: () => HackerDbObject = () => {
 		school: institutions.data[faker.random.number(1430)],
 		secondaryIds: [],
 		shirtSize: Object.values(ShirtSize)[faker.random.number(6)],
-		status: Object.values(ApplicationStatus)[faker.random.number(7)],
+		status: Object.values(ApplicationStatus)[faker.random.number(6)],
 		userType: UserType.Hacker,
 	};
 };


### PR DESCRIPTION
# Summary

If you run populateDb in its current state, the page will get stuck on the preloader, and you'll get the following error when you go to the `Manage Hackers` page:
```
[server] {"level":50,"time":1610911928639,"pid":22214,"hostname":"debian",
"message":"Invalid enum value: \"null\" is not in \"
[\"CREATED\",\"DECLINED\",\"STARTED\",\"SUBMITTED\",\"ACCEPTED\",\"CONFIRMED\",\"REJECTED\"]\"",
"locations":[{"line":9,"column":5}],"path":["hackers",13,"status"],"extensions":{"code":"BAD_USER_INPUT","exception":{"stacktrace":["UserInputError: Invalid enum value: \"null\" is not in \"[\"CREATED\",\"DECLINED\",\"STARTED\",\"SUBMITTED\",\"ACCEPTED\",\"CONFIRMED\",\"REJECTED\"]\"","    at /home/.../vaken/src/server/resolvers/helpers.ts:37:10","    at status (/home/.../vaken/src/server/resolvers/HackerResolver.ts:19:51)","    at processTicksAndRejections (internal/process/task_queues.js:93:5)"]}},"type":"Error","msg":"Invalid enum value: \"null\" is not in \"[\"CREATED\",\"DECLINED\",\"STARTED\",\"SUBMITTED\",\"ACCEPTED\",\"CONFIRMED\",\"REJECTED\"]\""}
```

This is because, in populateDb, `faker.random.number(7)` generates numbers from 0 - 7, but as one can see from the array above, valid indexes go from 0 - 6. Thus, when 7 is the index, null gets inserted, and you get an error. Changing this line to `faker.random.number(6)` fixes the issue!

Testing: Changing to 6 and running populateDb populates the `Manage Hackers` page successfully, and all 7 states show up on different inserted hackers.