### PR TITLE
Add sample atlas URL to sample env

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,7 +2,7 @@
 ASSET_PATH='/'
 
 # url to connect to mongo
-MONGODB_BASE_URL=localhost:27017
+MONGODB_BASE_URL=mongodb+srv://someusername:password@someurl.mongodb.net/vaken?retryWrites=true&w=majority
 
 # server port
 PORT=8080


### PR DESCRIPTION
# Summary

Given we recommend Atlas in the Contributing guide, it is better to have the sample URL represent that so the user knows it needs to be changed. If an advanced user has mongo locally, then they'll know it needs to be changed anyway but this would be useful to make it less confusing for newer folks.

Motivation: saw someone trying to set up Vaken locally.
