### PR TITLE
Revert loading React from cdn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25193,22 +25193,6 @@
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
-		"sri": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/sri/-/sri-1.1.0.tgz",
-			"integrity": "sha1-C1z2RiDkkLlf2AWwxxDXZpxTzf4=",
-			"dev": true
-		},
-		"sri-create": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/sri-create/-/sri-create-0.0.3.tgz",
-			"integrity": "sha512-4ZL3TLvPvu0y/3YpTkZdd441ykiRnrdWJuvus99WIT7NWTS2Dl/dFdZ7j0+zuL8cZPAKG2qGSdB+OLTBMRNuyQ==",
-			"dev": true,
-			"requires": {
-				"request": "^2.85.0",
-				"sri": "^1.1.0"
-			}
-		},
 		"sse-z": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/sse-z/-/sse-z-0.3.0.tgz",
@@ -27695,15 +27679,6 @@
 						"source-map": "^0.6.1"
 					}
 				}
-			}
-		},
-		"webpack-cdn-plugin": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/webpack-cdn-plugin/-/webpack-cdn-plugin-3.3.1.tgz",
-			"integrity": "sha512-xwhQ6xstFbPlgEkKNAOjXs/6YkPdzYeXl9na+CSBF7p1L88PZIGgL++vel4oiAnp+WTud7fhnSjlB79U6aN28w==",
-			"dev": true,
-			"requires": {
-				"sri-create": "^0.0.3"
 			}
 		},
 		"webpack-cli": {

--- a/package.json
+++ b/package.json
@@ -205,7 +205,6 @@
 		"typedoc": "^0.19.2",
 		"typescript": "^4.1.3",
 		"webpack": "^5.11.1",
-		"webpack-cdn-plugin": "^3.3.1",
 		"webpack-dev-server": "^3.11.1",
 		"webpack-merge": "^5.7.3"
 	},

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,6 +1,5 @@
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const WebpackCdnPlugin = require('webpack-cdn-plugin');
 const path = require('path');
 
 const ASSET_PATH = process.env.ASSET_PATH || '/';
@@ -47,24 +46,6 @@ module.exports = {
 			template: './src/client/index.html',
 			favicon: './src/client/assets/img/favicon.ico',
 		}), // For index.html entry point
-		new WebpackCdnPlugin({
-			modules: [
-				{
-					name: 'react',
-					var: 'React',
-					path: `umd/react.${
-						process.env.NODE_ENV === 'development' ? 'development' : 'production.min'
-					}.js`,
-				},
-				{
-					name: 'react-dom',
-					var: 'ReactDOM',
-					path: `umd/react-dom.${
-						process.env.NODE_ENV === 'development' ? 'development' : 'production.min'
-					}.js`,
-				},
-			],
-		}),
 	],
 	resolve: {
 		extensions: ['.ts', '.tsx', '.js', '.jsx', '.json'],


### PR DESCRIPTION
It turns out that loading from a CDN is incompatible with `helmet`, which sets content security policies disallowing loading scripts from other domains.

It's possible to make them coexist, but I'm not a security expert and the likelihood that I mess up the security configuration and expose everyone's personal information to attackers is... high, so we'll take the bundle hit and just bundle React and React-DOM.