### PR TITLE
Serialize and deserialze sessions with email and userType

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -92,7 +92,7 @@ export const schema = makeExecutableSchema({
 		// console.error(config); // sanity check for auth plugin
 	});
 
-	registerAuthRoutes(app, oAuthStrategies);
+	registerAuthRoutes(app, oAuthStrategies, models);
 
 	app.use((req, res, next) =>
 		passport.authenticate(


### PR DESCRIPTION
Fixes #522 by only serializing email and userType to DB. 

I'm not sure if it'd be even better if we made it query all three hacker + organizer + sponsor models, as that way a log-out wouldn't be required when switching user types, but I feel this problem is better fixed in the user interface overhaul.