### PR TITLE
Fix Storyshot inconsistencies 

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -12,6 +12,7 @@ import * as MeMocks from '../src/client/me.graphql.mocks';
 import * as ManageSponsorsMocks from '../src/client/routes/manage/sponsor.graphql.mocks';
 import * as ProfileMocks from '../src/client/routes/profile/user.graphql.mocks';
 import * as TeamMocks from '../src/client/routes/team/teams.graphql.mocks';
+import '@storybook/addon-console';
 
 export const parameters = {
 	actions: { argTypesRegex: '^on[A-Z].*' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13919,9 +13919,9 @@
 			"integrity": "sha512-EFTCh9zRSEpGPmJaexg7HTuzZHh6cnJj1ui7IGCFNXzd2QdpsNh05Db5TF3xzJm30YN+A8/6xHSuRcQqoc3kFA=="
 		},
 		"date-fns": {
-			"version": "1.30.1",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-			"integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+			"version": "2.19.0",
+			"resolved": "https://packages.convoy.com/artifactory/api/npm/npm/date-fns/-/date-fns-2.19.0.tgz",
+			"integrity": "sha1-ZRkzSGNaKNXZFsQ+x85vvRRQWeE="
 		},
 		"dateformat": {
 			"version": "3.0.3",
@@ -20504,6 +20504,11 @@
 					"requires": {
 						"restore-cursor": "^2.0.0"
 					}
+				},
+				"date-fns": {
+					"version": "1.30.1",
+					"resolved": "https://packages.convoy.com/artifactory/api/npm/npm/date-fns/-/date-fns-1.30.1.tgz",
+					"integrity": "sha1-LnG/CxGRU9u0zE6I2epaz7UNwFw="
 				},
 				"figures": {
 					"version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3928,6 +3928,15 @@
 				}
 			}
 		},
+		"@storybook/addon-console": {
+			"version": "1.2.3",
+			"resolved": "https://packages.convoy.com/artifactory/api/npm/npm/@storybook/addon-console/-/addon-console-1.2.3.tgz",
+			"integrity": "sha1-9siKj1T+AMjem3dyDq7yvB2qOvE=",
+			"dev": true,
+			"requires": {
+				"global": "^4.3.2"
+			}
+		},
 		"@storybook/addon-controls": {
 			"version": "6.1.20",
 			"resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-6.1.20.tgz",
@@ -27739,7 +27748,7 @@
 		"ts-node": {
 			"version": "9.1.1",
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-			"integrity": "sha1-UamkUKPpWUAb2l8ASnLVS5NtN20=",
+			"integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
 			"requires": {
 				"arg": "^4.1.0",
 				"create-require": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
 		"classnames": "^2.2.6",
 		"connect-mongo": "^3.2.0",
 		"csstype": "^3.0.5",
+		"date-fns": "^2.19.0",
 		"dotenv": "^8.2.0",
 		"email-validator": "^2.0.4",
 		"escape-html": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
 		"@babel/preset-typescript": "^7.12.7",
 		"@shelf/jest-mongodb": "^1.2.3",
 		"@storybook/addon-actions": "^6.1.11",
+		"@storybook/addon-console": "^1.2.3",
 		"@storybook/addon-essentials": "^6.1.20",
 		"@storybook/addon-links": "^6.1.11",
 		"@storybook/addon-storyshots": "^6.1.20",

--- a/src/client/routes/dashboard/OrganizerDash.stories.tsx
+++ b/src/client/routes/dashboard/OrganizerDash.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Meta, Story } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
 import { MockedProvider, MockedResponse } from '@apollo/client/testing';
-import Component, { GET_STATISTICS } from './OrganizerDash';
+import Component, { GET_STATISTICS, Props } from './OrganizerDash';
 
 export default {
 	title: 'Routes/Dashboard/Organizer Dash',
@@ -52,8 +52,11 @@ const mocks: MockedResponse[] = [
 	},
 ];
 
-export const OrganizerDash: Story<Record<string, unknown>> = args => (
+export const OrganizerDash: Story<Props> = args => (
 	<MockedProvider mocks={mocks}>
 		<Component {...args} />
 	</MockedProvider>
 );
+OrganizerDash.args = {
+	disableAnimations: true,
+};

--- a/src/client/routes/dashboard/OrganizerDash.tsx
+++ b/src/client/routes/dashboard/OrganizerDash.tsx
@@ -186,7 +186,7 @@ const REDUCED_MOTION_CHART_OPTIONS: ChartOptions = {
 	responsiveAnimationDuration: 0, // animation duration after a resize
 };
 
-interface Props {
+export interface Props {
 	disableAnimations?: boolean;
 }
 

--- a/src/common/mockObjects.ts
+++ b/src/common/mockObjects.ts
@@ -1,3 +1,4 @@
+import { parseISO } from 'date-fns';
 import { CHECK_IN_EVENT_TYPE } from '../client/routes/nfc/helpers';
 import {
 	ApplicationStatus,
@@ -131,10 +132,11 @@ export const MOCK_CHECK_IN_EVENT: Event = {
 	duration: 3600,
 	eventType: CHECK_IN_EVENT_TYPE,
 	id: '888',
-
-	// providing in ms since epoch form to ensure consistency for Storybook snapshots
-	// because JS Date constructor is evaluated in local time
-	startTimestamp: 1593820800000,
+	// set to July 4, 2030 at 00:00:00 UTC
+	// this lets us test out function that only work on current/future events
+	// while ensuring the time never changes ensuring test consistency
+	// hello from 2021 if Vaken is still in use in 2030 and you're wondering why this broke!
+	startTimestamp: parseISO('2030-07-04T00:00:00+0000').getTime(), // hard code for testing purposes
 	location: 'Atrium',
 	warnRepeatedCheckins: true,
 	name: 'Check In',

--- a/src/common/mockObjects.ts
+++ b/src/common/mockObjects.ts
@@ -131,7 +131,10 @@ export const MOCK_CHECK_IN_EVENT: Event = {
 	duration: 3600,
 	eventType: CHECK_IN_EVENT_TYPE,
 	id: '888',
-	startTimestamp: new Date().getTime(), // Always display this event.
+
+	// providing in ms since epoch form to ensure consistency for Storybook snapshots
+	// because JS Date constructor is evaluated in local time
+	startTimestamp: 1593820800000,
 	location: 'Atrium',
 	warnRepeatedCheckins: true,
 	name: 'Check In',

--- a/src/common/mockObjects.ts
+++ b/src/common/mockObjects.ts
@@ -129,14 +129,11 @@ export const MOCK_CHECK_IN_EVENT: Event = {
 	__typename: 'Event',
 	attendees: [tabeHackerId],
 	checkins: [{ user: tabeHackerId, id: '999', timestamp: new Date(2021, 3, 1).getTime() }],
-	duration: 3600,
+	// this lets us test out functionality that only work on current events
+	duration: Number.POSITIVE_INFINITY,
 	eventType: CHECK_IN_EVENT_TYPE,
 	id: '888',
-	// set to July 4, 2030 at 00:00:00 UTC
-	// this lets us test out function that only work on current/future events
-	// while ensuring the time never changes ensuring test consistency
-	// hello from 2021 if Vaken is still in use in 2030 and you're wondering why this broke!
-	startTimestamp: parseISO('2030-07-04T00:00:00+0000').getTime(), // hard code for testing purposes
+	startTimestamp: parseISO('2021-04-04T00:00:00+0000').getTime(), // hard code for testing purposes
 	location: 'Atrium',
 	warnRepeatedCheckins: true,
 	name: 'Check In',


### PR DESCRIPTION
# Summary

Noticed 3 issues (2 unique) with our Storyshots [here](https://happo.io/a/553/p/683/compare/9922e7935cd61988227d34e0194472fe3ddbbabc/5b4b70bca88b786ccddba86de5ef86524581a9a3).

- First seemed to have been caused by fairly innocuous shifting? Will approve this one manually
- Second was caused by mocked check-in date always being right now. Fixed this in this PR. Will approve in Happo.

Also added the ability to log in components and see the logs in the Storybook actions console. 'Tis great: https://github.com/storybookjs/storybook-addon-console/

