### PR TITLE
Add dotenv-webpack to work around storybookjs/storybook#14403

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6732,6 +6732,30 @@
 						"semver": "^6.3.0"
 					}
 				},
+				"dotenv": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+					"integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
+					"dev": true
+				},
+				"dotenv-defaults": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-1.1.1.tgz",
+					"integrity": "sha512-6fPRo9o/3MxKvmRZBD3oNFdxODdhJtIy1zcJeUSCs6HCy4tarUpd+G67UTU9tF6OWXeSPqsm4fPAB+2eY9Rt9Q==",
+					"dev": true,
+					"requires": {
+						"dotenv": "^6.2.0"
+					}
+				},
+				"dotenv-webpack": {
+					"version": "1.8.0",
+					"resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-1.8.0.tgz",
+					"integrity": "sha512-o8pq6NLBehtrqA8Jv8jFQNtG9nhRtVqmoD4yWbgUyoU3+9WBlPe+c2EAiaJok9RB28QvrWvdWLZGeTT5aATDMg==",
+					"dev": true,
+					"requires": {
+						"dotenv-defaults": "^1.0.2"
+					}
+				},
 				"enhanced-resolve": {
 					"version": "4.5.0",
 					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
@@ -9061,6 +9085,30 @@
 						"postcss-value-parser": "^4.1.0",
 						"schema-utils": "^2.7.0",
 						"semver": "^6.3.0"
+					}
+				},
+				"dotenv": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+					"integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
+					"dev": true
+				},
+				"dotenv-defaults": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-1.1.1.tgz",
+					"integrity": "sha512-6fPRo9o/3MxKvmRZBD3oNFdxODdhJtIy1zcJeUSCs6HCy4tarUpd+G67UTU9tF6OWXeSPqsm4fPAB+2eY9Rt9Q==",
+					"dev": true,
+					"requires": {
+						"dotenv": "^6.2.0"
+					}
+				},
+				"dotenv-webpack": {
+					"version": "1.8.0",
+					"resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-1.8.0.tgz",
+					"integrity": "sha512-o8pq6NLBehtrqA8Jv8jFQNtG9nhRtVqmoD4yWbgUyoU3+9WBlPe+c2EAiaJok9RB28QvrWvdWLZGeTT5aATDMg==",
+					"dev": true,
+					"requires": {
+						"dotenv-defaults": "^1.0.2"
 					}
 				},
 				"enhanced-resolve": {
@@ -17348,20 +17396,12 @@
 			"integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
 		},
 		"dotenv-defaults": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-1.1.1.tgz",
-			"integrity": "sha512-6fPRo9o/3MxKvmRZBD3oNFdxODdhJtIy1zcJeUSCs6HCy4tarUpd+G67UTU9tF6OWXeSPqsm4fPAB+2eY9Rt9Q==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz",
+			"integrity": "sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==",
 			"dev": true,
 			"requires": {
-				"dotenv": "^6.2.0"
-			},
-			"dependencies": {
-				"dotenv": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
-					"integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
-					"dev": true
-				}
+				"dotenv": "^8.2.0"
 			}
 		},
 		"dotenv-expand": {
@@ -17371,12 +17411,12 @@
 			"dev": true
 		},
 		"dotenv-webpack": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-1.8.0.tgz",
-			"integrity": "sha512-o8pq6NLBehtrqA8Jv8jFQNtG9nhRtVqmoD4yWbgUyoU3+9WBlPe+c2EAiaJok9RB28QvrWvdWLZGeTT5aATDMg==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-7.0.3.tgz",
+			"integrity": "sha512-O0O9pOEwrk+n1zzR3T2uuXRlw64QxHSPeNN1GaiNBloQFNaCUL9V8jxSVz4jlXXFP/CIqK8YecWf8BAvsSgMjw==",
 			"dev": true,
 			"requires": {
-				"dotenv-defaults": "^1.0.2"
+				"dotenv-defaults": "^2.0.2"
 			}
 		},
 		"downshift": {

--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
 		"concurrently": "^5.3.0",
 		"copy-webpack-plugin": "^6.4.1",
 		"css-loader": "^5.0.1",
+		"dotenv-webpack": "^7.0.3",
 		"error-overlay-webpack-plugin": "^0.4.2",
 		"eslint": "^7.16.0",
 		"eslint-config-airbnb": "^18.2.1",


### PR DESCRIPTION
https://github.com/storybookjs/storybook/issues/14497 and https://github.com/storybookjs/storybook/issues/14403

tl;dr: Happo stopped working because `npm run build-storybook` was failing after #818 upgraded webpack to a new minor version and threw us into the weird implicit hoisting mess described below.

Theoretically this is a workaround and can be removed after https://github.com/storybookjs/storybook/issues/14403 is resolved, but there is no sign of when that'll happen

Deep technical reasons from the linked issue for why this fails:

> If npm hoists dotenv-webpack 6.0.4 to the node_modules root, everything works fine. However, if npm hoists dotenv-webpack 1.8, and the user has a .env file present, start-storybook fails to run.
>
> Unless the user is already pinning dotenv-webpack, the version that gets hoisted depends on how many dependencies are using 1.8 vs 6.0.4. (For example, in the repro steps below, if you remove @storybook/addon-essentials, npm hoists 6.0.4 and things work normally.) This makes for some extremely surprising and hard-to-pin-down behavior.