### PR TITLE
Trim whitespace for required questions

### DIFF
--- a/src/client/routes/application/Application.tsx
+++ b/src/client/routes/application/Application.tsx
@@ -101,7 +101,8 @@ const findRequiredUnfilled = (input: ApplicationInput[]): string => {
 	const requiredQuestion = config
 		.flatMap(section => section.fields as ConfigField[])
 		.find(
-			field => !field.optional && !input.find(el => el.question === field.fieldName && el.answer)
+			field =>
+				!field.optional && !input.find(el => el.question === field.fieldName && el.answer.trim())
 		);
 	return requiredQuestion ? `[${requiredQuestion.title}] is required` : '';
 };


### PR DESCRIPTION
Currently, you can submit an application with your first name, last name, phone #, school, major as just a bunch of spaces.

This PR prevents that at least for required fields.

We should still have some validation for non-required fields but I am not sure of the best way to go about that.

fixes 4 of Nisala's bugs.