### PR TITLE
Fixing button box-shadow styling collision

### DIFF
--- a/src/client/components/Input/Slider.tsx
+++ b/src/client/components/Input/Slider.tsx
@@ -53,14 +53,14 @@ const SliderContainer = styled.div`
 		}
 	}
 
-	input:not(:checked):focus + label {
+	input:not(:checked):focus-within + label {
 		/* Color for keyboard users */
-		box-shadow: inset 0 0 2px 2px ${STRINGS.ACCENT_COLOR_DARK};
+		box-shadow: 0 0 2px 2px ${STRINGS.ACCENT_COLOR_DARK};
 	}
 
-	input:checked:focus + label {
+	input:checked:focus-within + label {
 		/* Color for keyboard users */
-		box-shadow: inset 0 0 2px 2px #ffffff;
+		box-shadow: 0 0 2px 2px #ffffff;
 	}
 `;
 


### PR DESCRIPTION
# Summary

Changed the styling of the button when clicked, used to have a collision of box-shadow and background making it seem like its blurred (due to :focus selector for keyboard users).

Initial:
<img width="494" alt="Screen Shot 2021-09-19 at 23 31 57" src="https://user-images.githubusercontent.com/31333688/133957387-f4985041-2edb-499d-b7d9-6e976f9a79c0.png">
Now:
<img width="504" alt="Screen Shot 2021-09-19 at 23 31 35" src="https://user-images.githubusercontent.com/31333688/133957368-09cbe9ef-abeb-4e9a-9a1d-df0e775d81cb.png">
