### PR TITLE
Recreating organizer dashboard pr

### DIFF
--- a/src/client/assets/routes.js
+++ b/src/client/assets/routes.js
@@ -4,11 +4,12 @@ import { HackerDash } from '../routes/dashboard/HackerDash';
 import { Help } from '../routes/help/Help';
 import { UserType } from '../generated/graphql';
 import { packages } from '../plugins';
+import OrganizerDash from '../routes/dashboard/OrganizerDash';
 
 const routes = [
 	{
 		authLevel: [UserType.Organizer],
-		component: HackerDash,
+		component: OrganizerDash,
 		displayText: 'Dashboard',
 		path: '/dashboard',
 	},

--- a/src/client/routes/dashboard/OrganizerDash.tsx
+++ b/src/client/routes/dashboard/OrganizerDash.tsx
@@ -1,6 +1,5 @@
 import React, { FC } from 'react';
 import { Bar, Pie, ChartData } from 'react-chartjs-2';
-import { gql, useQuery } from '@apollo/client';
 import styled from 'styled-components';
 import { ChartData as ChartJSData, ChartOptions } from 'chart.js';
 

--- a/src/client/routes/manage/hackers.graphql.ts
+++ b/src/client/routes/manage/hackers.graphql.ts
@@ -44,7 +44,6 @@ export default gql`
 			school
 			status
 			eventsAttended
-			attendingInPerson
 			gender
 			shirtSize
 		}

--- a/src/client/routes/manage/hackers.graphql.ts
+++ b/src/client/routes/manage/hackers.graphql.ts
@@ -44,6 +44,9 @@ export default gql`
 			school
 			status
 			eventsAttended
+			attendingInPerson
+			gender
+			shirtSize
 		}
 	}
 


### PR DESCRIPTION
# Summary

The organizer dash no longer throws an error. Instead, useful charts about cumulative t-shirt sizes, application status, and gender are shown.

# Review Focus 

Anything you want the reviewer to pay attention to? Feel free to delete this section.