### PR TITLE
Fix organizer redirect

### DIFF
--- a/src/client/routes/dashboard/Frame.tsx
+++ b/src/client/routes/dashboard/Frame.tsx
@@ -159,7 +159,7 @@ const Frame: FunctionComponent = (): JSX.Element => {
 								{() => {
 									switch (currentUser.userType) {
 										case UserType.Organizer:
-											return <OrganizerDash />;
+											return <HackerDash />;
 										case UserType.Sponsor:
 											return <SponsorDash />;
 										case UserType.Hacker:

--- a/src/client/routes/dashboard/Frame.tsx
+++ b/src/client/routes/dashboard/Frame.tsx
@@ -20,8 +20,6 @@ import { UserType } from '../../generated/graphql';
 import { HackerDash } from './HackerDash';
 import { SponsorDash } from './SponsorDash';
 
-export const OrganizerDash = React.lazy(() => import('./OrganizerDash'));
-
 const Layout = styled.div`
 	position: fixed;
 	height: 100vh;


### PR DESCRIPTION
# Summary

Fixes the annoying error screen whenever an organizer logs into Vaken. Currently, OrganizerDash is not implemented. In routes, Organizers are just routed to the HackerDash anyways, which is why clicking on "Dashboard" on the left menu works in the first place. This just makes this behavior the default.