### PR TITLE
Add confirmation before accepting or rejecting offer

### DIFF
--- a/src/client/routes/dashboard/HackerDash.tsx
+++ b/src/client/routes/dashboard/HackerDash.tsx
@@ -153,15 +153,23 @@ export const HackerDash: FunctionComponent = (): JSX.Element => {
 
 	useEffect((): void => {
 		statusConfig[ApplicationStatus.Accepted].actions[0].action = () => {
-			confirmMySpot()
-				.then(() => setShowConfetti(true))
-				.catch(err => console.error(err));
+			// eslint-disable-next-line no-alert
+			const confirmed = window.confirm('Are you sure you want to confirm your spot?');
+			if (confirmed) {
+				confirmMySpot()
+					.then(() => setShowConfetti(true))
+					.catch(err => console.error(err));
+			}
 			return undefined;
 		};
 		statusConfig[ApplicationStatus.Accepted].actions[1].action = () => {
-			declineMySpot()
-				// no confetti :(
-				.catch(err => console.error(err));
+			// eslint-disable-next-line no-alert
+			const confirmed = window.confirm('Are you sure you want to decline your spot?');
+			if (confirmed) {
+				declineMySpot()
+					// no confetti :(
+					.catch(err => console.error(err));
+			}
 			return undefined;
 		};
 	}, [confirmMySpot, declineMySpot]);


### PR DESCRIPTION
# Summary

This displays a confirmation alert before the user accepts or rejects their offer (N-59).

# Review Focus 

My local setup can't accept or reject offer. I would recommend you make sure it's just a configuration issue on my end.